### PR TITLE
Fixes #14 Make Address a Sealed Class

### DIFF
--- a/src/Hashgraph/Address.cs
+++ b/src/Hashgraph/Address.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿using Hashgraph.Implementation;
+using System;
 
 namespace Hashgraph
 {
     /// <summary>
     /// Represents a Hedera Network Account Address.
     /// </summary>
-    public class Address : IEquatable<Address>
+    public sealed class Address : IEquatable<Address>
     {
         /// <summary>
         /// Network Realm Number for Account
@@ -33,21 +34,9 @@ namespace Hashgraph
         /// </param>
         public Address(long realmNum, long shardNum, long accountNum)
         {
-            if (realmNum < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(realmNum), "Realm Number cannot be negative.");
-            }
-            if (shardNum < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(shardNum), "Shard Number cannot be negative.");
-            }
-            if (accountNum < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(accountNum), "Account Number cannot be negative.");
-            }
-            RealmNum = realmNum;
-            ShardNum = shardNum;
-            AccountNum = accountNum;
+            RealmNum = Validate.RealmNumberArgument(realmNum);
+            ShardNum = Validate.ShardNumberArgument(shardNum);
+            AccountNum = Validate.AcountNumberArgument(accountNum);
         }
         /// <summary>
         /// Equality implementation.

--- a/src/Hashgraph/CreateAccountRecord.cs
+++ b/src/Hashgraph/CreateAccountRecord.cs
@@ -5,7 +5,7 @@ namespace Hashgraph
     /// <summary>
     /// A transaction record containing information concerning the newly created account.
     /// </summary>
-    public class CreateAccountRecord : TransactionRecord
+    public sealed class CreateAccountRecord : TransactionRecord
     {
         /// <summary>
         /// The address of the newly created account.

--- a/src/Hashgraph/Gateway.cs
+++ b/src/Hashgraph/Gateway.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Hashgraph.Implementation;
+using System;
 
 namespace Hashgraph
 {
@@ -12,12 +13,34 @@ namespace Hashgraph
     /// network address where the public network endpoint is located.
     /// This class is immutable once created.
     /// </remarks>
-    public sealed class Gateway : Address, IEquatable<Gateway>
+    public sealed class Gateway : IEquatable<Gateway>
     {
         /// <summary>
         /// The URL and port of the public Hedera Network access point.
         /// </summary>
         public string Url { get; private set; }
+        /// <summary>
+        /// Network Realm Number for Gateway Account
+        /// </summary>
+        public long RealmNum { get; private set; }
+        /// <summary>
+        /// Network Shard Number for Gateway Account
+        /// </summary>
+        public long ShardNum { get; private set; }
+        /// <summary>
+        /// Network Account Number for Gateway Account
+        /// </summary>
+        public long AccountNum { get; private set; }
+        /// <summary>
+        /// Public Constructor, a <code>Gateway</code> is immutable after creation.
+        /// </summary>
+        /// <param name="url">
+        /// The URL and port of the public Hedera Network access point.
+        /// </param>
+        /// <param name="address">
+        /// Main Network Node Address
+        /// </param>
+        public Gateway(string url, Address address) : this(url, address.RealmNum, address.ShardNum, address.AccountNum) { }
         /// <summary>
         /// Public Constructor, a <code>Gateway</code> is immutable after creation.
         /// </summary>
@@ -33,10 +56,12 @@ namespace Hashgraph
         /// <param name="accountNum">
         /// Main Network Node Account Number
         /// </param>
-        public Gateway(string url, long realmNum, long shardNum, long accountNum) :
-            base(realmNum, shardNum, accountNum)
+        public Gateway(string url, long realmNum, long shardNum, long accountNum)
         {
-            Url = url;
+            Url = Validate.UrlArgument(url);
+            RealmNum = Validate.RealmNumberArgument(realmNum);
+            ShardNum = Validate.ShardNumberArgument(shardNum);
+            AccountNum = Validate.AcountNumberArgument(accountNum);
         }
         /// <summary>
         /// Equality implementation.
@@ -139,6 +164,17 @@ namespace Hashgraph
         public static bool operator !=(Gateway left, Gateway right)
         {
             return !(left == right);
+        }
+        /// <summary>
+        /// Implicit operator for converting a Gateway to an Address
+        /// </summary>
+        /// <param name="gateway">
+        /// The Gateway object containing the realm, shard and account 
+        /// number address information to convert into an address object.
+        /// </param>
+        public static implicit operator Address(Gateway gateway)
+        {
+            return new Address(gateway.RealmNum, gateway.ShardNum, gateway.AccountNum);
         }
     }
 }

--- a/src/Hashgraph/Implementation/Validate.cs
+++ b/src/Hashgraph/Implementation/Validate.cs
@@ -1,4 +1,5 @@
 ﻿using Proto;
+using System;
 
 namespace Hashgraph.Implementation
 {
@@ -14,6 +15,41 @@ namespace Hashgraph.Implementation
                 return;
             }
             throw new PrecheckException($"Transaction Failed Pre-Check: {code}", Protobuf.FromTransactionId(transactionId), (ResponseCode)code);
+        }
+
+        internal static long AcountNumberArgument(long accountNum)
+        {
+            if (accountNum < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(accountNum), "Account Number cannot be negative.");
+            }
+            return accountNum;
+        }
+
+        internal static long ShardNumberArgument(long shardNum)
+        {
+            if (shardNum < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(shardNum), "Shard Number cannot be negative.");
+            }
+            return shardNum;
+        }
+
+        internal static long RealmNumberArgument(long realmNum)
+        {
+            if (realmNum < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(realmNum), "Realm Number cannot be negative.");
+            }
+            return realmNum;
+        }
+        internal static string UrlArgument(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentOutOfRangeException(nameof(url), "URL is required.");
+            }
+            return url;
         }
     }
 }

--- a/src/Hashgraph/TxId.cs
+++ b/src/Hashgraph/TxId.cs
@@ -11,7 +11,7 @@ namespace Hashgraph
     /// interface and can be compared to other transaction ids returned 
     /// from the library.
     /// </summary>
-    public class TxId : IData, IEquatable<TxId>
+    public sealed class TxId : IData, IEquatable<TxId>
     {
         /// <summary>
         /// Data storing the internal representation of the transaction id.  


### PR DESCRIPTION
Made Address a sealed class, broke inheritance
from Gateway and Account objects and added
implicit operators to compensate.  A Gateway
object can be passed as an address, and Account
can be passed as an Address but not in the
other direction.