### PR TITLE
Fixes #59 Remove ShardID & RealmID

### DIFF
--- a/src/Hashgraph/File/CreateFile.cs
+++ b/src/Hashgraph/File/CreateFile.cs
@@ -73,8 +73,6 @@ namespace Hashgraph
                 ExpirationTime = Protobuf.ToTimestamp(createParameters.Expiration),
                 Keys = Protobuf.ToPublicKeyList(createParameters.Endorsements),
                 Contents = ByteString.CopyFrom(createParameters.Contents.ToArray()),
-                ShardID = Protobuf.ToShardID(gateway.ShardNum),
-                RealmID = Protobuf.ToRealmID(gateway.RealmNum, gateway.ShardNum)
             };
             var request = Transactions.SignTransaction(transactionBody, payer);
             var response = await Transactions.ExecuteRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);

--- a/src/Hashgraph/Implementation/Protobuf.cs
+++ b/src/Hashgraph/Implementation/Protobuf.cs
@@ -28,20 +28,6 @@ namespace Hashgraph.Implementation
             return TransactionID.Parser.ParseFrom((transaction as IData).Data.ToArray());
         }
 
-        internal static ShardID ToShardID(long shardNum)
-        {
-            return new ShardID { ShardNum = shardNum };
-        }
-
-        internal static RealmID ToRealmID(long realmNum, long shardNum)
-        {
-            return new RealmID
-            {
-                RealmNum = realmNum,
-                ShardNum = shardNum
-            };
-        }
-
         internal static AccountID ToAccountID(Address address)
         {
             return new AccountID


### PR DESCRIPTION
Shard and Realm are currently ignored with
"create" functions on the network.