### PR TITLE
Fixes #93 Remove Generate Record Flag

### DIFF
--- a/src/Hashgraph/IContext.cs
+++ b/src/Hashgraph/IContext.cs
@@ -47,12 +47,6 @@ namespace Hashgraph
         /// </summary>
         string? Memo { get; set; }
         /// <summary>
-        /// Flag indicating that network requests should generate a signed 
-        /// network record for the transaction.
-        /// </summary>
-        [Obsolete("Generate Record Flag has been deprecated and will soon be removed.")]
-        bool GenerateRecord { get; set; }
-        /// <summary>
         /// If set to <code>true</code> the library client will automatically
         /// scan for <see cref="ResponseCode.InvalidTransactionStart"/> responses
         /// from the server and adjust the automatic generation of transaction

--- a/src/Hashgraph/Implementation/ContextStack.cs
+++ b/src/Hashgraph/Implementation/ContextStack.cs
@@ -25,8 +25,6 @@ namespace Hashgraph.Implementation
         public int RetryCount { get => get<int>(nameof(RetryCount)); set => set(nameof(RetryCount), value); }
         public TimeSpan RetryDelay { get => get<TimeSpan>(nameof(RetryDelay)); set => set(nameof(RetryDelay), value); }
         public string? Memo { get => get<string>(nameof(Memo)); set => set(nameof(Memo), value); }
-        [Obsolete("Generate Record Flag has been deprecated and will soon be removed.")]
-        public bool GenerateRecord { get => get<bool>(nameof(GenerateRecord)); set => set(nameof(GenerateRecord), value); }
         public bool AdjustForLocalClockDrift { get => get<bool>(nameof(AdjustForLocalClockDrift)); set => set(nameof(AdjustForLocalClockDrift), value); }
         public TxId? Transaction { get => get<TxId>(nameof(Transaction)); set => set(nameof(Transaction), value); }
         public Action<IMessage>? OnSendingRequest { get => get<Action<IMessage>>(nameof(OnSendingRequest)); set => set(nameof(OnSendingRequest), value); }
@@ -50,7 +48,6 @@ namespace Hashgraph.Implementation
                 case nameof(RetryDelay):
                 case nameof(TransactionDuration):
                 case nameof(Memo):
-                case nameof(GenerateRecord):
                 case nameof(AdjustForLocalClockDrift):
                 case nameof(Transaction):
                 case nameof(OnSendingRequest):

--- a/src/Hashgraph/Implementation/Transactions.cs
+++ b/src/Hashgraph/Implementation/Transactions.cs
@@ -73,7 +73,6 @@ namespace Hashgraph
                 NodeAccountID = Protobuf.ToAccountID(RequireInContext.Gateway(context)),
                 TransactionFee = (ulong)context.FeeLimit,
                 TransactionValidDuration = Protobuf.ToDuration(context.TransactionDuration),
-                GenerateRecord = context.GenerateRecord,
                 Memo = context.Memo ?? defaultMemo ?? "",
             };
         }

--- a/test/Hashgraph.Test/ContextStackTests.cs
+++ b/test/Hashgraph.Test/ContextStackTests.cs
@@ -184,33 +184,6 @@ namespace Hashgraph.Tests
                 Assert.Null(context.Memo);
             });
         }
-        [Fact(DisplayName = "Context: Can Set and Reset Generate Record Property")]
-        public async Task CanSetAndUnsetGenerateRecord()
-        {
-            var defaultValue = false;
-            var newValue = false;
-            await using var client = new Client(context =>
-            {
-                defaultValue = context.GenerateRecord;
-                newValue = !defaultValue;
-                context.GenerateRecord = newValue;
-                Assert.Equal(newValue, context.GenerateRecord);
-            });
-            await using var clone = client.Clone(context =>
-            {
-                Assert.Equal(newValue, context.GenerateRecord);
-            });
-            client.Configure(context =>
-            {
-                Assert.Equal(newValue, context.GenerateRecord);
-                context.Reset(nameof(IContext.GenerateRecord));
-                Assert.Equal(defaultValue, context.GenerateRecord);
-            });
-            clone.Configure(context =>
-            {
-                Assert.Equal(defaultValue, context.GenerateRecord);
-            });
-        }
         [Fact(DisplayName = "Context: Can Set and Reset Retry Count Property")]
         public async Task CanSetAndUnsetRetryCount()
         {


### PR DESCRIPTION
The Generate Record Flag is depricated in the
protobuf repository (and has not really been in
use anyway), with the upcomming testnet upgrade
it is likely prudent to remove this as to not get
compiler errors if it is removed in the next upgrade.