### PR TITLE
Fixes #99 Add Proxy Stake Account

### DIFF
--- a/src/Hashgraph/Crypto/CreateAccount.cs
+++ b/src/Hashgraph/Crypto/CreateAccount.cs
@@ -85,6 +85,7 @@ namespace Hashgraph
                 ReceiveRecordThreshold = createParameters.ReceiveThresholdCreateRecord,
                 ReceiverSigRequired = createParameters.RequireReceiveSignature,
                 AutoRenewPeriod = Protobuf.ToDuration(createParameters.AutoRenewPeriod),
+                ProxyAccountID = createParameters.Proxy is null ? null : Protobuf.ToAccountID(createParameters.Proxy),
             };
             var request = Transactions.SignTransaction(transactionBody, payer);
             var precheck = await Transactions.ExecuteRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);

--- a/src/Hashgraph/Crypto/CreateAccountParams.cs
+++ b/src/Hashgraph/Crypto/CreateAccountParams.cs
@@ -58,5 +58,12 @@ namespace Hashgraph
         /// hbars sufficient to cover the renewal charge.
         /// </summary>
         public TimeSpan AutoRenewPeriod { get; set; } = TimeSpan.FromDays(31);
+        /// <summary>
+        /// The account to which the created account will proxy its stake to.
+        /// If null or is an invalid, or is the account that is not a node, or the
+        /// node does not accept proxy staking; then this account is automatically 
+        /// proxy staked to a node chosen by the network without earning payments.
+        /// </summary>
+        public Address? Proxy { get; set; }
     }
 }

--- a/src/Hashgraph/Crypto/UpdateAccount.cs
+++ b/src/Hashgraph/Crypto/UpdateAccount.cs
@@ -93,6 +93,10 @@ namespace Hashgraph
             {
                 updateAccountBody.ExpirationTime = Protobuf.ToTimestamp(updateParameters.Expiration.Value);
             }
+            if (!(updateParameters.Proxy is null))
+            {
+                updateAccountBody.ProxyAccountID = Protobuf.ToAccountID(updateParameters.Proxy);
+            }
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Update Account");
             transactionBody.CryptoUpdateAccount = updateAccountBody;

--- a/src/Hashgraph/Crypto/UpdateAccountParams.cs
+++ b/src/Hashgraph/Crypto/UpdateAccountParams.cs
@@ -57,5 +57,12 @@ namespace Hashgraph
         /// account will be deleted.
         /// </summary>
         public TimeSpan? AutoRenewPeriod { get; set; }
+        /// <summary>
+        /// The account to which the created account will proxy its stake to.
+        /// If invalid, or is the account that is not a node, or the
+        /// node does not accept proxy staking; then this account is automatically 
+        /// proxy staked to a node chosen by the network without earning payments.
+        /// </summary>
+        public Address? Proxy { get; set; }
     }
 }

--- a/src/Hashgraph/Implementation/RequireInputParameter.cs
+++ b/src/Hashgraph/Implementation/RequireInputParameter.cs
@@ -138,7 +138,8 @@ namespace Hashgraph.Implementation
                 updateParameters.SendThresholdCreateRecord is null &&
                 updateParameters.ReceiveThresholdCreateRecord is null &&
                 updateParameters.Expiration is null &&
-                updateParameters.AutoRenewPeriod is null)
+                updateParameters.AutoRenewPeriod is null &&
+                updateParameters.Proxy is null)
             {
                 throw new ArgumentException(nameof(updateParameters), "The Account Updates contains no update properties, it is blank.");
             }

--- a/test/Hashgraph.Test/Crypto/CreateAccountTests.cs
+++ b/test/Hashgraph.Test/Crypto/CreateAccountTests.cs
@@ -37,6 +37,7 @@ namespace Hashgraph.Test.Crypto
             Assert.Equal(createResult.Address.RealmNum, info.Address.RealmNum);
             Assert.Equal(createResult.Address.ShardNum, info.Address.ShardNum);
             Assert.Equal(createResult.Address.AccountNum, info.Address.AccountNum);
+            Assert.Equal(new Address(0,0,0), info.Proxy);
             Assert.False(info.Deleted);
 
             // Move remaining funds back to primary account.
@@ -138,6 +139,22 @@ namespace Hashgraph.Test.Crypto
 
             var info = await client.GetAccountInfoAsync(createResult.Address);
             Assert.Equal(expectedValue, info.AutoRenewPeriod);
+        }
+        [Fact(DisplayName = "Create Account: Set Account Proxy Stake")]
+        public async Task CanSetProxyStakeAccount()
+        {
+            var (publicKey, privateKey) = Generator.KeyPair();
+            await using var client = _network.NewClient();
+            var createResult = await client.CreateAccountAsync(new CreateAccountParams
+            {
+                InitialBalance = 1,
+                PublicKey = publicKey,
+                Proxy = _network.Gateway,
+            });
+            Assert.Equal(ResponseCode.Success, createResult.Status);
+
+            var info = await client.GetAccountInfoAsync(createResult.Address);
+            Assert.Equal(_network.Gateway,info.Proxy);
         }
     }
 }

--- a/test/Hashgraph.Test/Crypto/GetInfoTests.cs
+++ b/test/Hashgraph.Test/Crypto/GetInfoTests.cs
@@ -27,9 +27,7 @@ namespace Hashgraph.Test.Crypto
             Assert.NotNull(info.SmartContractId);
             Assert.False(info.Deleted);
             Assert.NotNull(info.Proxy);
-            Assert.True(info.Proxy.RealmNum > -1);
-            Assert.True(info.Proxy.ShardNum > -1);
-            Assert.True(info.Proxy.AccountNum > -1);
+            Assert.Equal(new Address(0, 0, 0), info.Proxy);
             Assert.Equal(0, info.ProxiedToAccount);
             Assert.Equal(new Endorsement(_network.PublicKey), info.Endorsement);
             Assert.True(info.Balance > 0);
@@ -51,9 +49,7 @@ namespace Hashgraph.Test.Crypto
             Assert.NotNull(info.SmartContractId);
             Assert.False(info.Deleted);
             Assert.NotNull(info.Proxy);
-            Assert.True(info.Proxy.RealmNum > -1);
-            Assert.True(info.Proxy.ShardNum > -1);
-            Assert.True(info.Proxy.AccountNum > -1);
+            Assert.Equal(new Address(0, 0, 0), info.Proxy);
             Assert.True(info.ProxiedToAccount > -1);
             Assert.True(info.Balance > 0);
             Assert.True(info.SendThresholdCreateRecord > 0);

--- a/test/Hashgraph.Test/Crypto/UpdateAccountTests.cs
+++ b/test/Hashgraph.Test/Crypto/UpdateAccountTests.cs
@@ -125,5 +125,47 @@ namespace Hashgraph.Test.Crypto
             var updatedInfo = await client.GetAccountInfoAsync(createResult.Address);
             Assert.Equal(newValue, updatedInfo.AutoRenewPeriod);
         }
+        [Fact(DisplayName = "Update Account: Can Update Proxy Stake")]
+        public async Task CanUpdateProxyStake()
+        {
+            var fx = await TestAccount.CreateAsync(_network);
+
+            var originalInfo = await fx.Client.GetAccountInfoAsync(fx.Record.Address);
+            Assert.Equal(new Address(0, 0, 0), originalInfo.Proxy);
+
+            var updateResult = await fx.Client.UpdateAccountAsync(new UpdateAccountParams
+            {
+                Account = new Account(fx.Record.Address, fx.PrivateKey),
+                Proxy = _network.Gateway
+            });
+            Assert.Equal(ResponseCode.Success, updateResult.Status);
+
+            var updatedInfo = await fx.Client.GetAccountInfoAsync(fx.Record.Address);
+            Assert.Equal(_network.Gateway, updatedInfo.Proxy);
+        }
+        [Fact(DisplayName = "Update Account: Can Update Proxy Stake to Invalid Address")]
+        public async Task CanUpdateProxyStakeToInvalidAddress()
+        {
+            var emptyAddress = new Address(0, 0, 0);
+            var fx = await TestAccount.CreateAsync(_network);
+            await fx.Client.UpdateAccountAsync(new UpdateAccountParams
+            {
+                Account = new Account(fx.Record.Address, fx.PrivateKey),
+                Proxy = _network.Gateway
+            });
+
+            var originalInfo = await fx.Client.GetAccountInfoAsync(fx.Record.Address);
+            Assert.Equal(_network.Gateway, originalInfo.Proxy);
+
+            var updateResult = await fx.Client.UpdateAccountAsync(new UpdateAccountParams
+            {
+                Account = new Account(fx.Record.Address, fx.PrivateKey),
+                Proxy = emptyAddress
+            });
+            Assert.Equal(ResponseCode.Success, updateResult.Status);
+
+            var updatedInfo = await fx.Client.GetAccountInfoAsync(fx.Record.Address);
+            Assert.Equal(emptyAddress, updatedInfo.Proxy);
+        }
     }
 }


### PR DESCRIPTION
Re-added proxy stake account to Account Create
and Account Update method parameters.  One can
now set the proxystake for an account.