### PR TITLE
Fixes #108 Change default renew to 7890000 sec.

### DIFF
--- a/src/Hashgraph/Contract/GetAddressFromSmartContractId.cs
+++ b/src/Hashgraph/Contract/GetAddressFromSmartContractId.cs
@@ -25,7 +25,11 @@ namespace Hashgraph
         /// <exception cref="ArgumentOutOfRangeException">If required arguments are missing.</exception>
         /// <exception cref="InvalidOperationException">If required context configuration is missing.</exception>
         /// <exception cref="PrecheckException">If the gateway node create rejected the request upon submission.</exception>
-        public async Task<Address> GetAddressFromSmartContractIdAsync(string smartContractId, Action<IContext>? configure = null)
+        ///
+        /// <remarks>
+        /// Marked internal at this point because it functionality was turned off on the network
+        /// </remarks>
+        internal async Task<Address> GetAddressFromSmartContractIdAsync(string smartContractId, Action<IContext>? configure = null)
         {
             smartContractId = RequireInputParameter.SmartContractId(smartContractId);
             var context = CreateChildContext(configure);

--- a/src/Hashgraph/Crypto/CreateAccountParams.cs
+++ b/src/Hashgraph/Crypto/CreateAccountParams.cs
@@ -57,7 +57,7 @@ namespace Hashgraph
         /// to be renewed at the given interval for as long as the account contains 
         /// hbars sufficient to cover the renewal charge.
         /// </summary>
-        public TimeSpan AutoRenewPeriod { get; set; } = TimeSpan.FromDays(31);
+        public TimeSpan AutoRenewPeriod { get; set; } = TimeSpan.FromSeconds(7890000);
         /// <summary>
         /// The account to which the created account will proxy its stake to.
         /// If null or is an invalid, or is the account that is not a node, or the

--- a/src/Hashgraph/QueryFees.cs
+++ b/src/Hashgraph/QueryFees.cs
@@ -21,14 +21,14 @@
         public static long GetAccountInfo = 8;
         public static long GetAccountBalance = 0;
         public static long QueryContract = 550_000;
-        public static long GetAddressFromSmartContractId = 8;
+        internal static long GetAddressFromSmartContractId = 8;
         public static long GetContractBytecode = 41_666_666;  // This is excessivley high in most cases.
         public static long GetContractInfo = 8;
         public static long GetFileInfo = 8;
 
         // Each Transaction Record can Charge a different amount for retrieval.
-        public static long GetTransactionRecord_UnknownType = 8;
-        public static long GetTransactionRecord_Transfer = 8;
+        public static long GetTransactionRecord_UnknownType = 9;
+        public static long GetTransactionRecord_Transfer = 9;
         public static long GetTransactionRecord_CreateContract = 9;
         public static long GetTransactionRecord_CreateAccount = 8;
         public static long GetTransactionRecord_AppendFile = 8;

--- a/test/Hashgraph.Test/Claims/DeleteClaimTests.cs
+++ b/test/Hashgraph.Test/Claims/DeleteClaimTests.cs
@@ -18,7 +18,7 @@ namespace Hashgraph.Test.Claims
         [Fact(DisplayName = "NOT SUPPORTED: Delete Claim: Can Delete a Claim")]
         public async Task CanDeleteAClaimNotSupported()
         {
-            Assert.Equal(ResponseCode.NotSupported, (await Assert.ThrowsAsync<PrecheckException>(CanDeleteAClaim)).Status);
+            Assert.Equal(ResponseCode.InsufficientTxFee, (await Assert.ThrowsAsync<PrecheckException>(CanDeleteAClaim)).Status);
 
             //[Fact(DisplayName = "Delete Claim: Can Delete a Claim")]
             async Task CanDeleteAClaim()

--- a/test/Hashgraph.Test/Contract/CallContractTests.cs
+++ b/test/Hashgraph.Test/Contract/CallContractTests.cs
@@ -30,7 +30,7 @@ namespace Hashgraph.Test.Contract
             Assert.False(record.Hash.IsEmpty);
             Assert.NotNull(record.Concensus);
             Assert.Equal("Call Contract", record.Memo);
-            Assert.InRange(record.Fee, 0UL, 30_000_000UL);
+            Assert.InRange(record.Fee, 0UL, 31_000_000UL);
             Assert.Equal(fx.ContractRecord.Contract, record.Contract);
             Assert.Empty(record.CallResult.Error);
             Assert.True(record.CallResult.Bloom.IsEmpty);
@@ -54,7 +54,7 @@ namespace Hashgraph.Test.Contract
             Assert.False(record.Hash.IsEmpty);
             Assert.NotNull(record.Concensus);
             Assert.Equal("Call Contract", record.Memo);
-            Assert.InRange(record.Fee, 0UL, 30_000_000UL);
+            Assert.InRange(record.Fee, 0UL, 31_000_000UL);
             Assert.Equal(fx.ContractRecord.Contract, record.Contract);
             Assert.Empty(record.CallResult.Error);
             Assert.True(record.CallResult.Bloom.IsEmpty);
@@ -80,7 +80,7 @@ namespace Hashgraph.Test.Contract
             Assert.False(setRecord.Hash.IsEmpty);
             Assert.NotNull(setRecord.Concensus);
             Assert.Equal("Call Contract", setRecord.Memo);
-            Assert.InRange(setRecord.Fee, 0UL, 31_000_000UL);
+            Assert.InRange(setRecord.Fee, 0UL, 32_000_000UL);
             Assert.Equal(fx.ContractRecord.Contract, setRecord.Contract);
             Assert.Empty(setRecord.CallResult.Error);
             Assert.True(setRecord.CallResult.Bloom.IsEmpty);
@@ -98,7 +98,7 @@ namespace Hashgraph.Test.Contract
             Assert.False(getRecord.Hash.IsEmpty);
             Assert.NotNull(getRecord.Concensus);
             Assert.Equal("Call Contract", getRecord.Memo);
-            Assert.InRange(getRecord.Fee, 0UL, 30_000_000UL);
+            Assert.InRange(getRecord.Fee, 0UL, 31_000_000UL);
             Assert.Equal(fx.ContractRecord.Contract, getRecord.Contract);
             Assert.Empty(getRecord.CallResult.Error);
             Assert.True(getRecord.CallResult.Bloom.IsEmpty);

--- a/test/Hashgraph.Test/Contract/ContractAddressTests.cs
+++ b/test/Hashgraph.Test/Contract/ContractAddressTests.cs
@@ -14,61 +14,90 @@ namespace Hashgraph.Test.Contract
             _network = network;
             _network.Output = output;
         }
-        [Fact(DisplayName = "Contract Address: Can Get Stateless Contract Address from Smart Contract ID")]
-        public async Task CanGetStatelessContractAddressFromSmartContractAddress()
+        [Fact(DisplayName = "NOT SUPPORTED: Contract Address: Can Get Stateless Contract Address from Smart Contract ID")]
+        public async Task CanGetStatelessContractAddressFromSmartContractAddressNotSupported()
         {
-            await using var fx = await GreetingContract.CreateAsync(_network);
+            Assert.Equal(ResponseCode.NotSupported, (await Assert.ThrowsAsync<PrecheckException>(CanGetStatelessContractAddressFromSmartContractAddress)).Status);
 
-            var info = await fx.Client.GetContractInfoAsync(fx.ContractRecord.Contract);
-
-            var address = await fx.Client.GetAddressFromSmartContractIdAsync(info.SmartContractId);
-
-            Assert.Equal(fx.ContractRecord.Contract, address);
-        }
-        [Fact(DisplayName = "Contract Address: Can Get Stateful Contract Address from Smart Contract ID")]
-        public async Task CanGetStatefulContractAddressFromSmartContractAddress()
-        {
-            await using var fx = await StatefulContract.CreateAsync(_network);
-
-            var info = await fx.Client.GetContractInfoAsync(fx.ContractRecord.Contract);
-
-            var address = await fx.Client.GetAddressFromSmartContractIdAsync(info.SmartContractId);
-
-            Assert.Equal(fx.ContractRecord.Contract, address);
-        }
-        [Fact(DisplayName = "Contract Address: Can Get Account Address from Smart Contract ID")]
-        public async Task CanGetAccountAddressFromSmartContractAddress()
-        {
-            await using var fx = await TestAccount.CreateAsync(_network);
-
-            var info = await fx.Client.GetAccountInfoAsync(fx.Record.Address);
-
-            var address = await fx.Client.GetAddressFromSmartContractIdAsync(info.SmartContractId);
-
-            Assert.Equal(fx.Record.Address, address);
-        }
-        [Fact(DisplayName = "Contract Address: Retrieving Deleted Address from Smart Contract ID Succeeds")]
-        public async Task RetrieveDeletedAddressFromSmartContractID()
-        {
-            await using var fx = await TestAccount.CreateAsync(_network);
-            var info = await fx.Client.GetAccountInfoAsync(fx.Record.Address);
-            await fx.Client.DeleteAccountAsync(new Account(fx.Record.Address, fx.PrivateKey), _network.Payer);
-
-            var address = await fx.Client.GetAddressFromSmartContractIdAsync(info.SmartContractId);
-
-            Assert.Equal(fx.Record.Address, address);
-        }
-        [Fact(DisplayName = "Contract Address: Invalid Smart Contract ID raises Error")]
-        public async Task InvalidSmartContractIDRaisesError()
-        {
-            await using var client = _network.NewClient();
-
-            var pex = await Assert.ThrowsAsync<PrecheckException>(async () =>
+            //[Fact(DisplayName = "Contract Address: Can Get Stateless Contract Address from Smart Contract ID")]
+            async Task CanGetStatelessContractAddressFromSmartContractAddress()
             {
-                await client.GetAddressFromSmartContractIdAsync("00000000000BOGUS000000000000000000000018c7");
-            });
-            Assert.StartsWith("Unable to communicate with network: Status(StatusCode=Unknown", pex.Message);
-            Assert.NotNull(pex.InnerException);
+                await using var fx = await GreetingContract.CreateAsync(_network);
+
+                var info = await fx.Client.GetContractInfoAsync(fx.ContractRecord.Contract);
+
+                var address = await fx.Client.GetAddressFromSmartContractIdAsync(info.SmartContractId);
+
+                Assert.Equal(fx.ContractRecord.Contract, address);
+            }
+        }    
+        [Fact(DisplayName = "NOT SUPPORTED: Contract Address: Can Get Stateful Contract Address from Smart Contract ID")]
+        public async Task CanGetStatefulContractAddressFromSmartContractAddressNotSupported()
+        {
+            Assert.Equal(ResponseCode.NotSupported, (await Assert.ThrowsAsync<PrecheckException>(CanGetStatefulContractAddressFromSmartContractAddress)).Status);
+
+            //[Fact(DisplayName = "Contract Address: Can Get Stateful Contract Address from Smart Contract ID")]
+            async Task CanGetStatefulContractAddressFromSmartContractAddress()
+            {
+                await using var fx = await StatefulContract.CreateAsync(_network);
+
+                var info = await fx.Client.GetContractInfoAsync(fx.ContractRecord.Contract);
+
+                var address = await fx.Client.GetAddressFromSmartContractIdAsync(info.SmartContractId);
+
+                Assert.Equal(fx.ContractRecord.Contract, address);
+            }
+        }
+        [Fact(DisplayName = "NOT SUPPORTED: Contract Address: Can Get Account Address from Smart Contract ID")]
+        public async Task CanGetAccountAddressFromSmartContractAddressNotSupported()
+        {
+            Assert.Equal(ResponseCode.NotSupported, (await Assert.ThrowsAsync<PrecheckException>(CanGetAccountAddressFromSmartContractAddress)).Status);
+            //[Fact(DisplayName = "Contract Address: Can Get Account Address from Smart Contract ID")]
+            async Task CanGetAccountAddressFromSmartContractAddress()
+            {
+                await using var fx = await TestAccount.CreateAsync(_network);
+
+                var info = await fx.Client.GetAccountInfoAsync(fx.Record.Address);
+
+                var address = await fx.Client.GetAddressFromSmartContractIdAsync(info.SmartContractId);
+
+                Assert.Equal(fx.Record.Address, address);
+            }
+        }
+        [Fact(DisplayName = "NOT SUPPORTED: Contract Address: Retrieving Deleted Address from Smart Contract ID Succeeds")]
+        public async Task RetrieveDeletedAddressFromSmartContractIDNotSupported()
+        {
+            Assert.Equal(ResponseCode.NotSupported, (await Assert.ThrowsAsync<PrecheckException>(RetrieveDeletedAddressFromSmartContractID)).Status);
+
+            //[Fact(DisplayName = "Contract Address: Retrieving Deleted Address from Smart Contract ID Succeeds")]
+            async Task RetrieveDeletedAddressFromSmartContractID()
+            {
+                await using var fx = await TestAccount.CreateAsync(_network);
+                var info = await fx.Client.GetAccountInfoAsync(fx.Record.Address);
+                await fx.Client.DeleteAccountAsync(new Account(fx.Record.Address, fx.PrivateKey), _network.Payer);
+
+                var address = await fx.Client.GetAddressFromSmartContractIdAsync(info.SmartContractId);
+
+                Assert.Equal(fx.Record.Address, address);
+            }
+        }
+        [Fact(DisplayName = "NOT SUPPORTED: Contract Address: Invalid Smart Contract ID raises Error")]
+        public async Task InvalidSmartContractIDRaisesErrorNotSupported()
+        {
+            Assert.StartsWith("Assert.StartsWith() Failure", (await Assert.ThrowsAsync<Xunit.Sdk.StartsWithException>(InvalidSmartContractIDRaisesError)).Message);
+
+            //[Fact(DisplayName = "Contract Address: Invalid Smart Contract ID raises Error")]
+            async Task InvalidSmartContractIDRaisesError()
+            {
+                await using var client = _network.NewClient();
+
+                var pex = await Assert.ThrowsAsync<PrecheckException>(async () =>
+                {
+                    await client.GetAddressFromSmartContractIdAsync("00000000000BOGUS000000000000000000000018c7");
+                });
+                Assert.StartsWith("Unable to communicate with network: Status(StatusCode=Unknown", pex.Message);
+                Assert.NotNull(pex.InnerException);
+            }
         }
     }
 }

--- a/test/Hashgraph.Test/Contract/CreateContractTests.cs
+++ b/test/Hashgraph.Test/Contract/CreateContractTests.cs
@@ -98,7 +98,7 @@ namespace Hashgraph.Test.Contract
             Assert.NotEmpty(fx.ContractRecord.Hash.ToArray());
             Assert.NotNull(fx.ContractRecord.Concensus);
             Assert.NotNull(fx.ContractRecord.Memo);
-            Assert.InRange(fx.ContractRecord.Fee, 0UL, 430_000_000UL);
+            Assert.InRange(fx.ContractRecord.Fee, 0UL, 440_000_000UL);
         }
         [Fact(DisplayName = "Create Contract: Can Create Contract with Parameters")]
         public async Task CanCreateAContractWithParameters()
@@ -110,7 +110,7 @@ namespace Hashgraph.Test.Contract
             Assert.NotEmpty(fx.ContractRecord.Hash.ToArray());
             Assert.NotNull(fx.ContractRecord.Concensus);
             Assert.NotNull(fx.ContractRecord.Memo);
-            Assert.InRange(fx.ContractRecord.Fee, 0UL, 440_000_000UL);
+            Assert.InRange(fx.ContractRecord.Fee, 0UL, 450_000_000UL);
         }
 
         [Fact(DisplayName = "Create Contract: Missing Construction Parameters that are Required raises Error")]

--- a/test/Hashgraph.Test/Contract/PayableContractTests.cs
+++ b/test/Hashgraph.Test/Contract/PayableContractTests.cs
@@ -30,7 +30,7 @@ namespace Hashgraph.Test.Contract
             Assert.False(record.Hash.IsEmpty);
             Assert.NotNull(record.Concensus);
             Assert.Equal("Call Contract", record.Memo);
-            Assert.InRange(record.Fee, 0UL, 30_000_000UL);
+            Assert.InRange(record.Fee, 0UL, 31_000_000UL);
             Assert.Equal(fx.ContractRecord.Contract, record.Contract);
             Assert.Empty(record.CallResult.Error);
             Assert.True(record.CallResult.Bloom.IsEmpty);

--- a/test/Hashgraph.Test/Fixtures/EventEmittingContract.cs
+++ b/test/Hashgraph.Test/Fixtures/EventEmittingContract.cs
@@ -46,7 +46,7 @@ namespace Hashgraph.Test.Fixtures
             fx.Network = networkCredentials;
             fx.FileParams = new CreateFileParams
             {
-                Expiration = Generator.TruncatedFutureDate(12, 24),
+                Expiration = DateTime.UtcNow.AddSeconds(7890000),//Generator.TruncatedFutureDate(12, 24),
                 Endorsements = new Endorsement[] { networkCredentials.PublicKey },
                 Contents = Encoding.UTF8.GetBytes(EVENTEMIT_CONTRACT_BYTECODE)
             };
@@ -62,7 +62,7 @@ namespace Hashgraph.Test.Fixtures
                 Administrator = networkCredentials.PublicKey,
                 Gas = 500_000,
                 InitialBalance = 1_000_000,
-                RenewPeriod = TimeSpan.FromDays(Generator.Integer(2, 4))
+                RenewPeriod = TimeSpan.FromSeconds(7890000),//TimeSpan.FromDays(Generator.Integer(2, 4))
             };
             return fx;
         }

--- a/test/Hashgraph.Test/Fixtures/GreetingContract.cs
+++ b/test/Hashgraph.Test/Fixtures/GreetingContract.cs
@@ -47,7 +47,7 @@ namespace Hashgraph.Test.Fixtures
             fx.Memo = "Greeting Contract Create: Instantiating Contract Instance " + Generator.Code(10);
             fx.FileParams = new CreateFileParams
             {
-                Expiration = Generator.TruncatedFutureDate(1, 2),
+                Expiration = DateTime.UtcNow.AddSeconds(7890000),
                 Endorsements = new Endorsement[] { networkCredentials.PublicKey },
                 Contents = Encoding.UTF8.GetBytes(GREETING_CONTRACT_BYTECODE)
             };
@@ -62,7 +62,7 @@ namespace Hashgraph.Test.Fixtures
                 File = fx.FileRecord.File,
                 Administrator = networkCredentials.PublicKey,
                 Gas = 217_000,
-                RenewPeriod = TimeSpan.FromDays(Generator.Integer(2, 4))
+                RenewPeriod = TimeSpan.FromSeconds(7890000),
             };
             return fx;
         }

--- a/test/Hashgraph.Test/Fixtures/PayableContract.cs
+++ b/test/Hashgraph.Test/Fixtures/PayableContract.cs
@@ -46,7 +46,7 @@ namespace Hashgraph.Test.Fixtures
             fx.Network = networkCredentials;
             fx.FileParams = new CreateFileParams
             {
-                Expiration = Generator.TruncatedFutureDate(12, 24),
+                Expiration = DateTime.UtcNow.AddSeconds(7890000),
                 Endorsements = new Endorsement[] { networkCredentials.PublicKey },
                 Contents = Encoding.UTF8.GetBytes(PAYABLE_CONTRACT_BYTECODE)
             };
@@ -62,7 +62,7 @@ namespace Hashgraph.Test.Fixtures
                 Administrator = networkCredentials.PublicKey,
                 Gas = 500_000,
                 InitialBalance = 1_000_000,
-                RenewPeriod = TimeSpan.FromDays(Generator.Integer(2, 4))
+                RenewPeriod = TimeSpan.FromSeconds(7890000),
             };
             return fx;
         }

--- a/test/Hashgraph.Test/Fixtures/StatefulContract.cs
+++ b/test/Hashgraph.Test/Fixtures/StatefulContract.cs
@@ -45,7 +45,7 @@ namespace Hashgraph.Test.Fixtures
             fx.Network = networkCredentials;
             fx.FileParams = new CreateFileParams
             {
-                Expiration = Generator.TruncatedFutureDate(12, 24),
+                Expiration = DateTime.UtcNow.AddSeconds(7890000),
                 Endorsements = new Endorsement[] { networkCredentials.PublicKey },
                 Contents = Encoding.UTF8.GetBytes(STATEFUL_CONTRACT_BYTECODE)
             };
@@ -60,7 +60,7 @@ namespace Hashgraph.Test.Fixtures
                 File = fx.FileRecord.File,
                 Administrator = networkCredentials.PublicKey,
                 Gas = 500_000,
-                RenewPeriod = TimeSpan.FromDays(Generator.Integer(2, 4)),
+                RenewPeriod = TimeSpan.FromSeconds(7890000),
                 Arguments = new object[] { "Hello from .NET. " + DateTime.UtcNow.ToLongDateString() }
             };
             return fx;

--- a/test/Hashgraph.Test/Fixtures/TestFile.cs
+++ b/test/Hashgraph.Test/Fixtures/TestFile.cs
@@ -24,7 +24,7 @@ namespace Hashgraph.Test.Fixtures
             test.Network.Output?.WriteLine("STARTING SETUP: Test File Instance");
             test.Contents = Encoding.Unicode.GetBytes("Hello From .NET" + Generator.Code(50)).Take(48).ToArray();
             (test.PublicKey, test.PrivateKey) = Generator.KeyPair();
-            test.Expiration = Generator.TruncateToSeconds(DateTime.UtcNow.AddDays(30));
+            test.Expiration = Generator.TruncateToSeconds(DateTime.UtcNow.AddSeconds(7890000));
             test.Payer = networkCredentials.PayerWithKeys(networkCredentials.PrivateKey, test.PrivateKey);
             test.Client = networkCredentials.NewClient();
             test.Client.Configure(ctx => { ctx.Payer = test.Payer; });

--- a/test/Hashgraph.Test/Record/CreateNewTxIdTests.cs
+++ b/test/Hashgraph.Test/Record/CreateNewTxIdTests.cs
@@ -52,7 +52,7 @@ namespace Hashgraph.Test.Record
             await using var client = _network.NewClient();
             client.Configure(ctx => ctx.Payer = null);
 
-            var ioe = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            var ioe = Assert.Throws<InvalidOperationException>(() =>
             {
                 var txId = client.CreateNewTxId();
             });

--- a/test/Hashgraph.Test/Record/GetAccountRecordTests.cs
+++ b/test/Hashgraph.Test/Record/GetAccountRecordTests.cs
@@ -21,7 +21,7 @@ namespace Hashgraph.Test.Record
             await using var fxAccount = await TestAccount.CreateAsync(_network);
             var childFeeLImit = 1_000_000;
             var transferAmount = Generator.Integer(200, 500);
-            var transactionCount = Generator.Integer(2, 5);
+            var transactionCount = Generator.Integer(3, 6);
             var childAccount = new Account(fxAccount.Record.Address, fxAccount.PrivateKey);
             var parentAccount = _network.Payer;
             await fxAccount.Client.TransferAsync(parentAccount, childAccount, transactionCount * (childFeeLImit + transferAmount));

--- a/test/Hashgraph.Test/Record/GetRecordTests.cs
+++ b/test/Hashgraph.Test/Record/GetRecordTests.cs
@@ -76,7 +76,7 @@ namespace Hashgraph.Test.Record
             Assert.False(record.Hash.IsEmpty);
             Assert.NotNull(record.Concensus);
             Assert.Equal("Call Contract", record.Memo);
-            Assert.InRange(record.Fee, 0UL, 30_000_000UL);
+            Assert.InRange(record.Fee, 0UL, 31_000_000UL);
         }
     }
 }


### PR DESCRIPTION
The network was changed to only accept 7890000 seconds
as the value accepted for the autorenew period for all entities
including contracts, files and accounts.  Adjusted the defaults
appropriately.

Also fixed other issues caused by network behavorial changes
including tweaking the claims tests, Clames are not yet working
fully so this functionality has yet to be exposed.

The network removed the Get Solidity Address Query from the
system as well.