### PR TITLE
Fixes #108 Add Exchange Rate Info to Receipts

### DIFF
--- a/src/Hashgraph/ExchangeRate.cs
+++ b/src/Hashgraph/ExchangeRate.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Hashgraph
+{
+    /// <summary>
+    /// Exchange rate information as known by the 
+    /// hedera network.  Values returned in receipts.
+    /// </summary>
+    public class ExchangeRate
+    {
+        /// <summary>
+        /// Value which denote habar equivalent to USD Cent
+        /// </summary>
+        public int HBarPerUSDCent { get; set; }
+        /// <summary>
+        /// Value which denote USD Cents equivalent to Hbar
+        /// </summary>
+        public int USDCentPerHbar { get; set; }
+        /// <summary>
+        /// The date and time at which this exchange 
+        /// rate value is set to expire.
+        /// </summary>
+        public DateTime Expiration { get; set; }
+    }
+}

--- a/src/Hashgraph/Implementation/Protobuf.cs
+++ b/src/Hashgraph/Implementation/Protobuf.cs
@@ -14,7 +14,7 @@ namespace Hashgraph.Implementation
     /// protobuf messages.
     /// </summary>
     internal static class Protobuf
-    {        
+    {
         internal static TxId FromTransactionId(TransactionID transactionId)
         {
             return new TxId
@@ -102,6 +102,10 @@ namespace Hashgraph.Implementation
         internal static DateTime FromTimestamp(Timestamp timestamp)
         {
             return Epoch.ToDate(timestamp.Seconds, timestamp.Nanos);
+        }
+        internal static DateTime FromTimestamp(TimestampSeconds timestamp)
+        {
+            return Epoch.ToDate(timestamp.Seconds, 0);
         }
         internal static Key ToPublicKey(Endorsement endorsement)
         {
@@ -204,7 +208,13 @@ namespace Hashgraph.Implementation
         {
             result.Id = FromTransactionId(transactionId);
             result.Status = (ResponseCode)receipt.Status;
+            if (receipt.ExchangeRate != null)
+            {
+                result.CurrentExchangeRate = FromExchangeRate(receipt.ExchangeRate.CurrentRate);
+                result.NextExchangeRate = FromExchangeRate(receipt.ExchangeRate.NextRate);
+            }
         }
+
         internal static void FillRecordProperties(Proto.TransactionRecord record, TransactionRecord result)
         {
             result.Id = FromTransactionId(record.TransactionID);
@@ -214,6 +224,11 @@ namespace Hashgraph.Implementation
             result.Memo = record.Memo;
             result.Fee = record.TransactionFee;
             result.Transfers = FromTransferList(record.TransferList);
+            if (record.Receipt.ExchangeRate != null)
+            {
+                result.CurrentExchangeRate = FromExchangeRate(record.Receipt.ExchangeRate.CurrentRate);
+                result.NextExchangeRate = FromExchangeRate(record.Receipt.ExchangeRate.NextRate);
+            }
         }
         internal static ContractCallResult FromContractCallResult(ContractFunctionResult contractFunctionResult)
         {
@@ -241,6 +256,17 @@ namespace Hashgraph.Implementation
                 Hash = claim.Hash.ToByteArray(),
                 Endorsements = FromPublicKeyList(claim.Keys),
                 ClaimDuration = FromDuration(claim.ClaimDuration)
+            };
+        }
+        internal static ExchangeRate? FromExchangeRate(Proto.ExchangeRate rate)
+        {
+            return rate == null
+                ? null :
+            new ExchangeRate
+            {
+                HBarPerUSDCent = rate.HbarEquiv,
+                USDCentPerHbar = rate.CentEquiv,
+                Expiration = FromTimestamp(rate.ExpirationTime)
             };
         }
     }

--- a/src/Hashgraph/TransactionReceipt.cs
+++ b/src/Hashgraph/TransactionReceipt.cs
@@ -16,5 +16,23 @@ namespace Hashgraph
         /// The response code returned from the server.
         /// </summary>
         public ResponseCode Status { get; internal set; }
+        /// <summary>
+        /// The current exchange between USD and hBars as
+        /// broadcast by the hedera Network.
+        /// </summary>
+        /// <remarks>
+        /// Not all Receipts and Records will have this information
+        /// returned from the network.  This value can be <code>null</code>.
+        /// </remarks>
+        public ExchangeRate? CurrentExchangeRate { get; set; }
+        /// <summary>
+        /// The next/future exchange between USD and 
+        /// hBars as broadcast by the hedera Network.
+        /// </summary>
+        /// <remarks>
+        /// Not all Receipts and Records will have this information
+        /// returned from the network.  This value can be <code>null</code>.
+        /// </remarks>
+        public ExchangeRate? NextExchangeRate { get; set; }
     }
 }

--- a/test/Hashgraph.Test/Crypto/TransferTests.cs
+++ b/test/Hashgraph.Test/Crypto/TransferTests.cs
@@ -360,5 +360,29 @@ namespace Hashgraph.Test.Crypto
             Assert.InRange(txId.ValidStartSeconds, lowerBound / 1_000_000_000, upperBound / 1_000_000_000);
             Assert.InRange(txId.ValidStartNanos, 0, 1_000_000_000);
         }
+        [Fact(DisplayName = "Transfer: Receipt Contains Exchange Information")]
+        public async Task TransferReceiptContainsExchangeInformation()
+        {
+            await using var fx = await TestAccount.CreateAsync(_network);
+            var transferAmount = (long)Generator.Integer(10, 100);
+            var receipt = await fx.Client.TransferAsync(_network.Payer, fx.Record.Address, transferAmount);
+            Assert.NotNull(receipt.CurrentExchangeRate);
+            // Well, testnet doesn't actually have good data here
+            Assert.InRange(receipt.CurrentExchangeRate.Expiration, DateTime.MinValue, DateTime.MaxValue);
+            Assert.NotNull(receipt.NextExchangeRate);
+            Assert.InRange(receipt.NextExchangeRate.Expiration, DateTime.MinValue, DateTime.MaxValue);
+        }
+        [Fact(DisplayName = "Transfer: Receipt Contains Exchange Information")]
+        public async Task TransferRecordContainsExchangeInformation()
+        {
+            await using var fx = await TestAccount.CreateAsync(_network);
+            var transferAmount = (long)Generator.Integer(10, 100);
+            var record = await fx.Client.TransferWithRecordAsync(_network.Payer, fx.Record.Address, transferAmount);
+            Assert.NotNull(record.CurrentExchangeRate);
+            // Well, testnet doesn't actually have good data here
+            Assert.InRange(record.CurrentExchangeRate.Expiration, DateTime.MinValue, DateTime.MaxValue);
+            Assert.NotNull(record.NextExchangeRate);
+            Assert.InRange(record.NextExchangeRate.Expiration, DateTime.MinValue, DateTime.MaxValue);
+        }
     }
 }


### PR DESCRIPTION
Added the exchange rate information returned from
network calls in receipts and records.  Not all network
calls will return this information with recieipts and
records so calling code should always check for null
before trying to access the information.