### PR TITLE
Fixed Misleading Code and Comments

### DIFF
--- a/src/Hashgraph/ExchangeRate.cs
+++ b/src/Hashgraph/ExchangeRate.cs
@@ -5,17 +5,33 @@ namespace Hashgraph
     /// <summary>
     /// Exchange rate information as known by the 
     /// hedera network.  Values returned in receipts.
+    /// denominator.
     /// </summary>
+    /// <remarks>
+    /// The rate is expressed as parts of a numerator 
+    /// and denominator expressing the ratio of hbars
+    /// to cents. For example to get the value of 
+    /// $cent/hbar one would compute that as 
+    /// <code>USDCentEquivalent/HBarEquivalent</code>.
+    /// to get hbar/$cent one would compute that as
+    /// <code>HbarEquivalent/USDEquivalent</code>
+    /// This representation allows for fractions that might
+    /// otherwise be lost by floating point representations.
+    /// </remarks>
     public class ExchangeRate
     {
         /// <summary>
-        /// Value which denote habar equivalent to USD Cent
+        /// The HBar portion of the exchange rate, can be
+        /// used in the numerator to get hbars per cent or
+        /// in the denominator to get cents per hbar.
         /// </summary>
-        public int HBarPerUSDCent { get; set; }
+        public int HBarEquivalent { get; set; }
         /// <summary>
-        /// Value which denote USD Cents equivalent to Hbar
+        /// The USD cent portion of the exchange rate, can be
+        /// used in the numerator to get cents per hbar or
+        /// in the denominator to get hbars per cent.
         /// </summary>
-        public int USDCentPerHbar { get; set; }
+        public int USDCentEquivalent { get; set; }
         /// <summary>
         /// The date and time at which this exchange 
         /// rate value is set to expire.

--- a/src/Hashgraph/Implementation/Protobuf.cs
+++ b/src/Hashgraph/Implementation/Protobuf.cs
@@ -264,8 +264,8 @@ namespace Hashgraph.Implementation
                 ? null :
             new ExchangeRate
             {
-                HBarPerUSDCent = rate.HbarEquiv,
-                USDCentPerHbar = rate.CentEquiv,
+                HBarEquivalent = rate.HbarEquiv,
+                USDCentEquivalent = rate.CentEquiv,
                 Expiration = FromTimestamp(rate.ExpirationTime)
             };
         }


### PR DESCRIPTION
Previous version had an incorrect intrepretation
of the results returned from the network.  This
vesion has it correct.