### PR TITLE
Fixes #105 Support External Signing Code

### DIFF
--- a/src/Hashgraph/Claim/AddClaim.cs
+++ b/src/Hashgraph/Claim/AddClaim.cs
@@ -69,6 +69,7 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             var gateway = RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(payer));
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Add Claim");
             transactionBody.CryptoAddClaim = new CryptoAddClaimTransactionBody
@@ -81,7 +82,7 @@ namespace Hashgraph
                     ClaimDuration = Protobuf.ToDuration(claim.ClaimDuration)
                 }
             };
-            var request = Transactions.SignTransaction(transactionBody, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/Claim/DeleteClaim.cs
+++ b/src/Hashgraph/Claim/DeleteClaim.cs
@@ -75,6 +75,7 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(payer));
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Delete Claim");
             transactionBody.CryptoDeleteClaim = new CryptoDeleteClaimTransactionBody
@@ -82,7 +83,7 @@ namespace Hashgraph
                 AccountIDToDeleteFrom = Protobuf.ToAccountID(address),
                 HashToDelete = ByteString.CopyFrom(hash.ToArray())
             };
-            var request = Transactions.SignTransaction(transactionBody, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/Claim/GetClaim.cs
+++ b/src/Hashgraph/Claim/GetClaim.cs
@@ -51,7 +51,8 @@ namespace Hashgraph
             long cost = (long)response.CryptoGetClaim.Header.Cost;
             if (cost > 0)
             {
-                query.CryptoGetClaim.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get Claim Info", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.CryptoGetClaim.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Claim Info", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/Contract/CallContract.cs
+++ b/src/Hashgraph/Contract/CallContract.cs
@@ -73,6 +73,7 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             var gateway = RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(payer));
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Call Contract");
             transactionBody.ContractCall = new ContractCallTransactionBody
@@ -82,7 +83,7 @@ namespace Hashgraph
                 Amount = callParmeters.PayableAmount,
                 FunctionParameters = Abi.EncodeFunctionWithArguments(callParmeters.FunctionName, callParmeters.FunctionArgs).ToByteString()
             };
-            var request = Transactions.SignTransaction(transactionBody, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/Contract/CreateContract.cs
+++ b/src/Hashgraph/Contract/CreateContract.cs
@@ -67,6 +67,7 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             var gateway = RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(payer));
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Create Contract");
             transactionBody.ContractCreateInstance = new ContractCreateTransactionBody
@@ -79,7 +80,7 @@ namespace Hashgraph
                 ConstructorParameters = ByteString.CopyFrom(Abi.EncodeArguments(createParameters.Arguments).ToArray()),
                 Memo = context.Memo ?? "Create Contract"
             };
-            var request = Transactions.SignTransaction(transactionBody, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/Contract/DeleteContract.cs
+++ b/src/Hashgraph/Contract/DeleteContract.cs
@@ -39,6 +39,7 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(payer));
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Delete Contract");
             transactionBody.ContractDeleteInstance = new ContractDeleteTransactionBody
@@ -46,7 +47,7 @@ namespace Hashgraph
                 ContractID = Protobuf.ToContractID(contractToDelete),
                 TransferAccountID = Protobuf.ToAccountID(transferToAddress)
             };
-            var request = Transactions.SignTransaction(transactionBody, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/Contract/GetContractBytecode.cs
+++ b/src/Hashgraph/Contract/GetContractBytecode.cs
@@ -48,7 +48,8 @@ namespace Hashgraph
             long cost = (long)response.ContractGetBytecodeResponse.Header.Cost;
             if (cost > 0)
             {
-                query.ContractGetBytecode.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get Contract Bytecode", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.ContractGetBytecode.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Contract Bytecode", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/Contract/GetContractInfo.cs
+++ b/src/Hashgraph/Contract/GetContractInfo.cs
@@ -41,7 +41,8 @@ namespace Hashgraph
             long cost = (long)response.ContractGetInfo.Header.Cost;
             if (cost > 0)
             {
-                query.ContractGetInfo.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get Contract Info", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.ContractGetInfo.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Contract Info", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/Contract/QueryContract.cs
+++ b/src/Hashgraph/Contract/QueryContract.cs
@@ -50,7 +50,8 @@ namespace Hashgraph
             long cost = (long)response.ContractCallLocal.Header.Cost;
             if (cost > 0)
             {
-                query.ContractCallLocal.Header = Transactions.CreateAndSignQueryHeader(context, cost + queryParameters.ReturnValueCharge, "Query Contract Local Call", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.ContractCallLocal.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost + queryParameters.ReturnValueCharge, "Query Contract Local Call", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/Contract/UpdateContract.cs
+++ b/src/Hashgraph/Contract/UpdateContract.cs
@@ -69,6 +69,7 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(payer));
             var updateContractBody = new ContractUpdateTransactionBody
             {
                 ContractID = Protobuf.ToContractID(updateParameters.Contract)
@@ -96,7 +97,7 @@ namespace Hashgraph
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Update Contract");
             transactionBody.ContractUpdateInstance = updateContractBody;
-            var request = Transactions.SignTransaction(transactionBody, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/Crypto/DeleteAccount.cs
+++ b/src/Hashgraph/Crypto/DeleteAccount.cs
@@ -39,6 +39,7 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(accountToDelete), new Signatory(payer));
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Delete Account");
             transactionBody.CryptoDelete = new CryptoDeleteTransactionBody
@@ -46,7 +47,7 @@ namespace Hashgraph
                 DeleteAccountID = Protobuf.ToAccountID(accountToDelete),
                 TransferAccountID = Protobuf.ToAccountID(transferToAddress)
             };
-            var request = Transactions.SignTransaction(transactionBody, accountToDelete, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/Crypto/GetAccountBalance.cs
+++ b/src/Hashgraph/Crypto/GetAccountBalance.cs
@@ -41,7 +41,8 @@ namespace Hashgraph
             var cost = (long)response.CryptogetAccountBalance.Header.Cost;
             if (cost > 0)
             {
-                query.CryptogetAccountBalance.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get Account Balance", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.CryptogetAccountBalance.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Account Balance", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/Crypto/GetAccountInfo.cs
+++ b/src/Hashgraph/Crypto/GetAccountInfo.cs
@@ -41,7 +41,8 @@ namespace Hashgraph
             long cost = (long)response.CryptoGetInfo.Header.Cost;
             if (cost > 0)
             {
-                query.CryptoGetInfo.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get Account Info", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.CryptoGetInfo.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Account Info", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/Crypto/GetStakers.cs
+++ b/src/Hashgraph/Crypto/GetStakers.cs
@@ -47,7 +47,8 @@ namespace Hashgraph
             long cost = (long)response.CryptoGetProxyStakers.Header.Cost;
             if (cost > 0)
             {
-                query.CryptoGetProxyStakers.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get Proxy Stakers", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.CryptoGetProxyStakers.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Proxy Stakers", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/Crypto/UpdateAccount.cs
+++ b/src/Hashgraph/Crypto/UpdateAccount.cs
@@ -97,10 +97,11 @@ namespace Hashgraph
             {
                 updateAccountBody.ProxyAccountID = Protobuf.ToAccountID(updateParameters.Proxy);
             }
+            var signatory = Transactions.GatherSignatories(context, new Signatory(updateParameters.Account), new Signatory(payer));
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Update Account");
             transactionBody.CryptoUpdateAccount = updateAccountBody;
-            var request = Transactions.SignTransaction(transactionBody, updateParameters.Account, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/File/AppendFile.cs
+++ b/src/Hashgraph/File/AppendFile.cs
@@ -64,6 +64,7 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(payer));
             var appendFileBody = new FileAppendTransactionBody
             {
                 FileID = Protobuf.ToFileId(appendParameters.File),
@@ -72,7 +73,7 @@ namespace Hashgraph
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Append File Content");
             transactionBody.FileAppend = appendFileBody;
-            var request = Transactions.SignTransaction(transactionBody, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/File/CreateFile.cs
+++ b/src/Hashgraph/File/CreateFile.cs
@@ -66,6 +66,7 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             var gateway = RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(payer));
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Create File");
             transactionBody.FileCreate = new FileCreateTransactionBody
@@ -74,7 +75,7 @@ namespace Hashgraph
                 Keys = Protobuf.ToPublicKeyList(createParameters.Endorsements),
                 Contents = ByteString.CopyFrom(createParameters.Contents.ToArray()),
             };
-            var request = Transactions.SignTransaction(transactionBody, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/File/DeleteFile.cs
+++ b/src/Hashgraph/File/DeleteFile.cs
@@ -64,13 +64,14 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(payer));
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Delete File");
             transactionBody.FileDelete = new FileDeleteTransactionBody
             {
                 FileID = Protobuf.ToFileId(fileToDelete)
             };
-            var request = Transactions.SignTransaction(transactionBody, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/File/GetFileContent.cs
+++ b/src/Hashgraph/File/GetFileContent.cs
@@ -43,7 +43,8 @@ namespace Hashgraph
             long cost = (long)response.FileGetContents.Header.Cost;
             if (cost > 0)
             {
-                query.FileGetContents.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get File Contents", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.FileGetContents.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get File Contents", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/File/GetFileInfo.cs
+++ b/src/Hashgraph/File/GetFileInfo.cs
@@ -41,7 +41,8 @@ namespace Hashgraph
             long cost = (long)response.FileGetInfo.Header.Cost;
             if (cost > 0)
             {
-                query.FileGetInfo.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get File Info", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.FileGetInfo.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get File Info", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/File/UpdateFile.cs
+++ b/src/Hashgraph/File/UpdateFile.cs
@@ -67,6 +67,7 @@ namespace Hashgraph
             var context = CreateChildContext(configure);
             RequireInContext.Gateway(context);
             var payer = RequireInContext.Payer(context);
+            var signatory = Transactions.GatherSignatories(context, new Signatory(payer));
             var updateFileBody = new FileUpdateTransactionBody
             {
                 FileID = Protobuf.ToFileId(updateParameters.File)
@@ -82,7 +83,7 @@ namespace Hashgraph
             var transactionId = Transactions.GetOrCreateTransactionID(context);
             var transactionBody = Transactions.CreateTransactionBody(context, transactionId, "Update File");
             transactionBody.FileUpdate = updateFileBody;
-            var request = Transactions.SignTransaction(transactionBody, payer);
+            var request = await Transactions.SignTransactionAsync(transactionBody, signatory);
             var precheck = await Transactions.ExecuteSignedRequestWithRetryAsync(context, request, getRequestMethod, getResponseCode);
             ValidateResult.PreCheck(transactionId, precheck.NodeTransactionPrecheckCode);
             var receipt = await GetReceiptAsync(context, transactionId);

--- a/src/Hashgraph/IContext.cs
+++ b/src/Hashgraph/IContext.cs
@@ -33,6 +33,21 @@ namespace Hashgraph
         /// </summary>
         Account? Payer { get; set; }
         /// <summary>
+        /// The private key, keys or signing callback method that 
+        /// are needed to sign the transaction.  At a minimum, this
+        /// typically includes the Payer's signing key, but can also
+        /// include other signatories such as those required when 
+        /// creating claims, files and contracts.
+        /// </summary>
+        /// <remarks>
+        /// The library is currently in transition away from the
+        /// `Account` object that embeds signing keys in favor of
+        /// the explicit list of Signatories.  At some point in the
+        /// future, the `Payer` property will become a simple address
+        /// and the `Account` object will be removed from the library.
+        /// </remarks>
+        Signatory? Signatory { get; set; }
+        /// <summary>
         /// The maximum fee the payer is willing to pay for a transaction.
         /// </summary>
         long FeeLimit { get; set; }

--- a/src/Hashgraph/IInvoice.cs
+++ b/src/Hashgraph/IInvoice.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+namespace Hashgraph
+{
+    /// <summary>
+    /// Represents a pre-signed transaction request.  
+    /// This structure is passed to each configured 
+    /// <see cref="Signatory"/> and signatory callback
+    /// method to be given the opportunity to sign the
+    /// request before submitting it to the netwwork.
+    /// Typically, the signatory will use its private
+    /// key to sign the <see cref="TxBytes"/> serialized
+    /// representation of the transaciton request.  
+    /// This is the same series of bytes that are sent 
+    /// to the network along with the signatures 
+    /// collected from the signatories.
+    /// </summary>
+    public interface IInvoice
+    {
+        /// <summary>
+        /// The transaction ID assigned to this request. It,
+        /// by its nature, contains a timestamp and expiration.
+        /// Any callback methods must return from signing this
+        /// transaction with enough time for the transaction to
+        /// be submitted to the network with sufficient time to
+        /// process before becomming invalid.
+        /// </summary>
+        public TxId TxId { get; }
+        /// <summary>
+        /// The memo associated with this transaction, 
+        /// for convenience.
+        /// </summary>
+        public string Memo { get; }
+        /// <summary>
+        /// The bytes created by serializing the request, including
+        /// necessary cryptocurrency transfers, into the underlying
+        /// network's protobuf format.  This is the exact sequence
+        /// of bytes that will be submitted to the network along side
+        /// the signatures created authorizing the request.
+        /// </summary>
+        public ReadOnlyMemory<byte> TxBytes { get; }
+        /// <summary>
+        /// Adds a signature to the internal list of signatures
+        /// authorizing this request.
+        /// </summary>
+        /// <param name="type">
+        /// The type of signing key used for this signature.
+        /// </param>
+        /// <param name="publicPrefix">
+        /// The first few bytes of the public key associated
+        /// with this signature.  This helps the system match
+        /// signing requrements held internally in the form of
+        /// public keys with the signatures provided.
+        /// </param>
+        /// <param name="signature">
+        /// The bytes representing the signature corresponding
+        /// to the associated private/public key.
+        /// </param>
+        public void AddSignature(KeyType type, ReadOnlyMemory<byte> publicPrefix, ReadOnlyMemory<byte> signature);
+    }
+}

--- a/src/Hashgraph/Implementation/ContextStack.cs
+++ b/src/Hashgraph/Implementation/ContextStack.cs
@@ -20,6 +20,7 @@ namespace Hashgraph.Implementation
 
         public Gateway? Gateway { get => get<Gateway>(nameof(Gateway)); set => set(nameof(Gateway), value); }
         public Account? Payer { get => get<Account>(nameof(Payer)); set => set(nameof(Payer), value); }
+        public Signatory? Signatory { get => get<Signatory>(nameof(Signatory)); set => set(nameof(Signatory), value); }
         public long FeeLimit { get => get<long>(nameof(FeeLimit)); set => set(nameof(FeeLimit), value); }
         public TimeSpan TransactionDuration { get => get<TimeSpan>(nameof(TransactionDuration)); set => set(nameof(TransactionDuration), value); }
         public int RetryCount { get => get<int>(nameof(RetryCount)); set => set(nameof(RetryCount), value); }
@@ -43,6 +44,7 @@ namespace Hashgraph.Implementation
             {
                 case nameof(Gateway):
                 case nameof(Payer):
+                case nameof(Signatory):
                 case nameof(FeeLimit):
                 case nameof(RetryCount):
                 case nameof(RetryDelay):

--- a/src/Hashgraph/Implementation/ISignatory.cs
+++ b/src/Hashgraph/Implementation/ISignatory.cs
@@ -1,5 +1,4 @@
-﻿using Proto;
-using System;
+﻿using System.Threading.Tasks;
 
 namespace Hashgraph.Implementation
 {
@@ -7,8 +6,8 @@ namespace Hashgraph.Implementation
     /// Internal interface implemented by objects that 
     /// can sign transactions.  Not intended for public use.
     /// </summary>
-    internal interface ISigner
+    internal interface ISignatory
     {
-        SignaturePair[] Sign(ReadOnlyMemory<byte> data);
+        Task SignAsync(IInvoice invoice);
     }
 }

--- a/src/Hashgraph/Implementation/Invoice.cs
+++ b/src/Hashgraph/Implementation/Invoice.cs
@@ -1,0 +1,66 @@
+﻿using Google.Protobuf;
+using Proto;
+using System;
+using System.Collections.Generic;
+
+namespace Hashgraph.Implementation
+{
+    internal sealed class Invoice : IInvoice
+    {
+        private readonly TxId _txId;
+        private readonly string _memo;
+        private readonly ReadOnlyMemory<byte> _txBytes;
+        private readonly Dictionary<ByteString, SignaturePair> _signatures;
+
+        TxId IInvoice.TxId { get { return _txId; } }
+        string IInvoice.Memo { get { return _memo; } }
+        ReadOnlyMemory<byte> IInvoice.TxBytes { get { return _txBytes; } }
+        internal Invoice(TransactionBody transactionBody)
+        {
+            _txId = Protobuf.FromTransactionId(transactionBody.TransactionID);
+            _memo = transactionBody.Memo;
+            _txBytes = transactionBody.ToByteArray();
+            _signatures = new Dictionary<ByteString, SignaturePair>();
+        }
+        void IInvoice.AddSignature(KeyType type, ReadOnlyMemory<byte> publicPrefix, ReadOnlyMemory<byte> signature)
+        {
+            var key = ByteString.CopyFrom(publicPrefix.Span);
+            var value = ByteString.CopyFrom(signature.Span);
+            var pair = new Proto.SignaturePair { PubKeyPrefix = key };
+            switch (type)
+            {
+                case KeyType.Ed25519:
+                    pair.Ed25519 = value;
+                    break;
+                case KeyType.ECDSA384:
+                    pair.ECDSA384 = value;
+                    break;
+                case KeyType.RSA3072:
+                    pair.RSA3072 = value;
+                    break;
+                case KeyType.ContractID:
+                    pair.Contract = value;
+                    break;
+            }
+            _signatures[key] = pair;
+        }
+        internal Transaction GetSignedTransaction()
+        {
+            if(_signatures.Count == 0)
+            {
+                throw new InvalidOperationException("A transaction or query requires at least one signature, sometimes more.  None were found, did you forget to assign a Signatory to the context, transaction or query?");
+            }
+            var signatures = new SignatureMap();
+            foreach (var signature in _signatures.Values)
+            {
+                signatures.SigPair.Add(signature);
+            }            
+            return new Transaction
+            {
+                BodyBytes = ByteString.CopyFrom(_txBytes.Span),
+                SigMap = signatures
+            };
+        }
+    }
+}
+

--- a/src/Hashgraph/Implementation/RequireInputParameter.cs
+++ b/src/Hashgraph/Implementation/RequireInputParameter.cs
@@ -1,6 +1,7 @@
 ﻿using NSec.Cryptography;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Hashgraph.Implementation
 {
@@ -87,6 +88,7 @@ namespace Hashgraph.Implementation
             }
             return fromAccount;
         }
+
         internal static Address ToAddress(Address toAddress)
         {
             if (toAddress is null)
@@ -276,12 +278,12 @@ namespace Hashgraph.Implementation
         }
         internal static Key[] PrivateKeys(ReadOnlyMemory<byte>[] privateKeys)
         {
-            if (privateKeys.Length == 0)
+            if(privateKeys is null)
             {
-                throw new ArgumentOutOfRangeException(nameof(privateKeys), "The Account object constructor was given no private signing keys, it requires least one (do you need an Address object instead?)");
+                return new Key[0];
             }
             var result = new Key[privateKeys.Length];
-            for (int i = 0; i < privateKeys.Length; i++)
+            for (int i = 0; i < result.Length; i++)
             {
                 try
                 {
@@ -320,6 +322,33 @@ namespace Hashgraph.Implementation
                 throw new ArgumentOutOfRangeException(nameof(requiredCount), "The required number of keys for a valid signature cannot exceed the number of public keys provided.");
             }
             return requiredCount;
+        }
+        internal static Signatory[] Signatories(Signatory[] signatories)
+        {
+            if (signatories is null)
+            {
+                throw new ArgumentNullException(nameof(signatories), "The list of signatories may not be null.");
+            }
+            else if (signatories.Length == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(signatories), "At least one Signatory in a list is required.");
+            }
+            for (int i = 0; i < signatories.Length; i++)
+            {
+                if (signatories[i] is null)
+                {
+                    throw new ArgumentNullException(nameof(signatories), "No signatory within the list may be null.");
+                }
+            }
+            return signatories;
+        }
+        internal static Func<IInvoice, Task> SigningCallback(Func<IInvoice,Task> signingCallback)
+        {
+            if (signingCallback is null)
+            {
+                throw new ArgumentNullException(nameof(signingCallback), "The signing callback must not be null.");
+            }
+            return signingCallback;
         }
         internal static Proto.Key KeysFromCreateParameters(CreateAccountParams createParameters)
         {

--- a/src/Hashgraph/KeyType.cs
+++ b/src/Hashgraph/KeyType.cs
@@ -1,0 +1,28 @@
+﻿namespace Hashgraph
+{
+    /// <summary>
+    /// Key types supported by the network, this library
+    /// natively supports Ed25519, for signing with other
+    /// keys, the <see cref="Signatory" /> should use 
+    /// the callback form.
+    /// </summary>
+    public enum KeyType
+    {
+        /// <summary>
+        /// Ed25519 Key Pair
+        /// </summary>
+        Ed25519 = 1,
+        /// <summary>
+        /// RSA-3072 Key Pair
+        /// </summary>
+        RSA3072 = 2,
+        /// <summary>
+        /// ECDSA with the p-384 curve.
+        /// </summary>
+        ECDSA384 = 3,
+        /// <summary>
+        /// Smart Contract ID.
+        /// </summary>
+        ContractID = 4
+    }
+}

--- a/src/Hashgraph/Record/GetAccountRecords.cs
+++ b/src/Hashgraph/Record/GetAccountRecords.cs
@@ -44,7 +44,8 @@ namespace Hashgraph
             long cost = (long)response.CryptoGetAccountRecords.Header.Cost;
             if (cost > 0)
             {
-                query.CryptoGetAccountRecords.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get Account Records", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.CryptoGetAccountRecords.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Account Records", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/Record/GetContractRecords.cs
+++ b/src/Hashgraph/Record/GetContractRecords.cs
@@ -43,7 +43,8 @@ namespace Hashgraph
             long cost = (long)response.ContractGetRecordsResponse.Header.Cost;
             if (cost > 0)
             {
-                query.ContractGetRecords.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get Contract Records", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.ContractGetRecords.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Contract Records", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 ValidateResult.PreCheck(transactionId, getResponseCode(response));
             }

--- a/src/Hashgraph/Record/GetTransactionRecord.cs
+++ b/src/Hashgraph/Record/GetTransactionRecord.cs
@@ -80,7 +80,8 @@ namespace Hashgraph
             long cost = (long)response.TransactionGetRecord.Header.Cost;
             if (cost > 0)
             {
-                query.TransactionGetRecord.Header = Transactions.CreateAndSignQueryHeader(context, cost, "Get Transaction Record", out var transactionId);
+                var transactionId = Transactions.GetOrCreateTransactionID(context);
+                query.TransactionGetRecord.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Transaction Record", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
                 var responseCode = getResponseCode(response);
                 if (responseCode != ResponseCodeEnum.Ok)

--- a/src/Hashgraph/Signatory.cs
+++ b/src/Hashgraph/Signatory.cs
@@ -1,0 +1,389 @@
+﻿using Hashgraph.Implementation;
+using NSec.Cryptography;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Hashgraph
+{
+    /// <summary>
+    /// Represents a keyholder or group of keyholders that
+    /// can sign a transaction for crypto transfer to support
+    /// file creation, contract creation and execution or pay
+    /// for consensus services among other network tasks.
+    /// </summary>
+    /// <remarks>
+    /// A <code>Signatory</code> is presently created with a pre-existing
+    /// Ed25519 private key or a callback action having the
+    /// information necessary to sucessfully sign the transaction
+    /// as described by its matching <see cref="Endorsement" />
+    /// requrements.  RSA-3072, ECDSA and <code>Contract</code> signatures
+    /// are not natively supported thru the <code>Signatory</code> at this 
+    /// time but can be achieved thru the callback functionality.
+    /// </remarks>
+    public sealed class Signatory : ISignatory, IEquatable<Signatory>
+    {
+        /// <summary>
+        /// Private helper type tracking the type of signing
+        /// information held by this instance.
+        /// </summary>
+        private enum Type
+        {
+            /// <summary>
+            /// Ed25519 Public Key (Stored as a <see cref="NSec.Cryptography.PublicKey"/>).
+            /// </summary>
+            Ed25519 = 1,
+            /// <summary>
+            /// RSA-3072 Public Key (Stored as a <see cref="ReadOnlyMemory{Byte}"/>).
+            /// </summary>
+            /// <remarks>
+            /// Presently directly not supported, trying to create this type should 
+            /// result in thrown exception.
+            /// </remarks>
+            RSA3072 = 2,
+            /// <summary>
+            /// ECDSA with the p-384 curve (Stored as a <see cref="ReadOnlyMemory{Byte}"/>).
+            /// </summary>
+            /// <remarks>
+            /// Presently directly not supported, trying to create this type should 
+            /// result in a thrown exception.
+            /// </remarks>
+            ECDSA384 = 3,
+            /// <summary>
+            /// A <code>Func<IInvoice, Task> signingCallback</code> callback function 
+            /// having the knowledge to properly sign the binary representation of the 
+            /// transaction as serialized using the grpc protocol.
+            /// </summary>
+            Callback = 4,
+            /// <summary>
+            /// This signatory holds a list of a number of other signatories that can
+            /// in turn sign transactions.  This supports the sceneario where multiple
+            /// keys must sign a transaction.
+            /// </summary>
+            List = 5,
+            /// <summary>
+            /// This represnts legacy signing features in the library that are slated
+            /// for removal over time, such as the Ed25519 key(s) embedded in the
+            /// <see cref="Account"/> object.  At some point in the future 
+            /// <code>Account</code> will be replaced with <see cref="Address"/> 
+            /// and <code>Signatory</code> will be the sole means for communicating 
+            /// how to sign transactions.
+            /// </summary>
+            OtherSigner = 999
+        }
+        /// <summary>
+        /// Internal type of this Signatory.
+        /// </summary>
+        private readonly Type _type;
+        /// <summary>
+        /// Internal union of the types of data this Signatory may hold.
+        /// The contents are a function of the <code>Type</code>.  It can be a 
+        /// list of other signatories, a reference to a callback method, or an 
+        /// Ed25519 private key.
+        /// </summary>
+        private readonly object _data;
+        /// <summary>
+        /// Create a signatory with a private Ed25519 key.  When transactions
+        /// are signed, this signatory will automatically sign the transaction
+        /// with this private key.
+        /// </summary>
+        /// <param name="privateKey">
+        /// Bytes representing an Ed25519 private key signing transactions.  
+        /// It is expected to be 48 bytes in length, prefixed with 
+        /// <code>0x302e020100300506032b6570</code>.
+        /// </param>
+        public Signatory(ReadOnlyMemory<byte> privateKey) : this(KeyType.Ed25519, privateKey) { }
+        /// <summary>
+        /// Create a signatory that is a combination of a number of other
+        /// signatories.  When this signatory is called to sign a transaction
+        /// it will in turn ask all the child signatories in turn to sign the 
+        /// given transaction.
+        /// </summary>
+        /// <param name="Signatories">
+        /// One or more signatories that when combined can form a
+        /// multi key signature for the transaction.
+        /// </param>
+        public Signatory(params Signatory[] Signatories)
+        {
+            _type = Type.List;
+            _data = RequireInputParameter.Signatories(Signatories);
+        }
+        /// <summary>
+        /// Create a signatory having a private key of the specified type.
+        /// </summary>
+        /// <param name="type">
+        /// The type of private key this <code>Signatory</code> should use to 
+        /// sign transactions.
+        /// </param>
+        /// <param name="privateKey">
+        /// The bytes of a private key corresponding to the specified type.
+        /// </param>
+        /// <remarks>
+        /// At this time, the library only supports Ed25519 keys, any other
+        /// key type will result in an exception.  This is why this method
+        /// is marked as <code>internal</code> at the moment.  When the library 
+        /// can support other key types, it will make sense to make this public.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If any key type other than Ed25519 is used.
+        /// </exception>
+        internal Signatory(KeyType type, ReadOnlyMemory<byte> privateKey)
+        {
+            switch (type)
+            {
+                case KeyType.Ed25519:
+                    _type = Type.Ed25519;
+                    _data = Keys.ImportPrivateEd25519KeyFromBytes(privateKey);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), "Not a presently supported Signatory key type, please consider the callback signatory as an alternative.");
+            }
+        }
+        /// <summary>
+        /// Create a Signatory invoking the given async callback function
+        /// when asked to sign a transaction.  The <code>Signatory</code> 
+        /// will pass an instance of an <see cref="IInvoice"/> containing 
+        /// details of the transaction to sign when needed.  The callback 
+        /// function may add as many signatures as necessary to properly 
+        /// sign the  transaction.
+        /// </summary>
+        /// <param name="signingCallback">
+        /// An async callback method that is invoked when the library 
+        /// asks this Signatory to sign a transaction.
+        /// </param>
+        /// <remarks>
+        /// Note:  For a single transaction this method MAY BE CALLED TWICE
+        /// in the event the library is being asked to retrieve a record as
+        /// a part of the request.  This is because retrieving a record of 
+        /// a transaction requires a separate payment.  So, if this Signatory
+        /// is directly attached to the root <see cref="IContext"/> it will
+        /// be used to sign the request to retrieve the record (since this 
+        /// will typically represent the <see cref="IContext.Payer"/>'s 
+        /// signature for the transaction).
+        /// </remarks>
+        public Signatory(Func<IInvoice, Task> signingCallback)
+        {
+            _type = Type.Callback;
+            _data = RequireInputParameter.SigningCallback(signingCallback);
+        }
+        /// <summary>
+        /// Convenience implict cast for creating a <code>Signatory</code> 
+        /// directly from an Ed25519 private key.
+        /// </summary>
+        /// <param name="privateKey">
+        /// Bytes representing an Ed25519 private key signing transactions.  
+        /// It is expected to be 48 bytes in length, prefixed with 
+        /// <code>0x302e020100300506032b6570</code>.
+        /// </param>
+        public static implicit operator Signatory(ReadOnlyMemory<byte> privateKey)
+        {
+            return new Signatory(privateKey);
+        }
+        /// <summary>
+        /// Convenience implicit cast for creating a <code>Signatory</code> 
+        /// directly from a <code>Func<IInvoice, Task> signingCallback</code> 
+        /// callback
+        /// method.
+        /// </summary>
+        /// <param name="signingCallback">
+        /// An async callback method that is invoked when the library 
+        /// asks this Signatory to sign a transaction.
+        /// </param>
+        public static implicit operator Signatory(Func<IInvoice, Task> signingCallback)
+        {
+            return new Signatory(signingCallback);
+        }
+        /// <summary>
+        /// Equality implementation.
+        /// </summary>
+        /// <param name="other">
+        /// The other <code>Signatory</code> object to compare.
+        /// </param>
+        /// <returns>
+        /// True if public key layout and requirements are equivalent to the 
+        /// other <code>Signatory</code> object.
+        /// </returns>
+        public bool Equals(Signatory other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+            if (_type != other._type)
+            {
+                return false;
+            }
+            switch (_type)
+            {
+                case Type.Ed25519:
+                    return Equals(((Key)_data).PublicKey, ((Key)other._data).PublicKey);
+                case Type.RSA3072:  // Will need more work
+                case Type.ECDSA384: // Will need more work
+                    return Equals(_data, other._data);
+                case Type.List:
+                    var thisList = (Signatory[])_data;
+                    var otherList = (Signatory[])other._data;
+                    if (thisList.Length == otherList.Length)
+                    {
+                        for (int i = 0; i < thisList.Length; i++)
+                        {
+                            if (!thisList[i].Equals(otherList[i]))
+                            {
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                    break;
+                case Type.Callback:
+                    return ReferenceEquals(_data, other._data);
+            }
+            return false;
+        }
+        /// <summary>
+        /// Equality implementation.
+        /// </summary>
+        /// <param name="obj">
+        /// The other <code>Signatory</code> object to compare (if it is
+        /// an <code>Signatory</code>).
+        /// </param>
+        /// <returns>
+        /// If the other object is an Signatory, then <code>True</code> 
+        /// if key requirements are identical to the other 
+        /// <code>Signatories</code> object, otherwise 
+        /// <code>False</code>.
+        /// </returns>
+        public override bool Equals(object? obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            if (obj is Signatory other)
+            {
+                return Equals(other);
+            }
+            return false;
+        }
+        /// <summary>
+        /// Equality implementation.
+        /// </summary>
+        /// <returns>
+        /// A unique hash of the contents of this <code>Signatory</code> 
+        /// object.  Only consistent within the current instance of 
+        /// the application process.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            switch (_type)
+            {
+                case Type.Ed25519:
+                    return $"Signatory:{_type}:{((PublicKey)_data).GetHashCode().ToString()}".GetHashCode();
+                case Type.RSA3072:  // Will need more work
+                case Type.ECDSA384: // Will need more work
+                    return $"Signatory:{_type}:{_data}".GetHashCode();
+                case Type.Callback:
+                    return $"Signatory:{_type}:{_data.GetHashCode()}".GetHashCode();
+                case Type.List:
+                    return $"Signatory:{_type}:{string.Join(':', ((Signatory[])_data).Select(e => e.GetHashCode().ToString()))}".GetHashCode();
+            }
+            return "Endorsment:Empty".GetHashCode();
+        }
+        /// <summary>
+        /// Equals implementation.
+        /// </summary>
+        /// <param name="left">
+        /// Left hand <code>Signatory</code> argument.
+        /// </param>
+        /// <param name="right">
+        /// Right hand <code>Signatory</code> argument.
+        /// </param>
+        /// <returns>
+        /// True if Key requirements are identical 
+        /// within each <code>Signatory</code> objects.
+        /// </returns>
+        public static bool operator ==(Signatory left, Signatory right)
+        {
+            if (left is null)
+            {
+                return right is null;
+            }
+            return left.Equals(right);
+        }
+        /// <summary>
+        /// Not equals implementation.
+        /// </summary>
+        /// <param name="left">
+        /// Left hand <code>Signatory</code> argument.
+        /// </param>
+        /// <param name="right">
+        /// Right hand <code>Signatory</code> argument.
+        /// </param>
+        /// <returns>
+        /// <code>False</code> if the Key requirements are identical 
+        /// within each <code>Signatory</code> object.  
+        /// <code>True</code> if they are not identical.
+        /// </returns>
+        public static bool operator !=(Signatory left, Signatory right)
+        {
+            return !(left == right);
+        }
+        /// <summary>
+        /// Legacy support for components that also have
+        /// the ability to sign transactions.  Used only internally
+        /// by the library.
+        /// </summary>
+        /// <param name="signer">
+        /// The legacy signer instance (such as a <see cref="Account"/>).
+        /// </param>
+        internal Signatory(ISignatory signer)
+        {
+            _type = Type.OtherSigner;
+            _data = signer;
+        }
+        /// <summary>
+        /// Implement the signing algorithm.  In the case of an Ed25519
+        /// it will use the private key to sign the transaction and 
+        /// return immediately.  In the case of the callback method, it 
+        /// will pass the invoice to the async method and async await
+        /// for the method to return.
+        /// </summary>
+        /// <param name="invoice">
+        /// The information for the transaction, including the Transaction 
+        /// ID, Memo and serialized bytes of the crypto transfers and other
+        /// embedded information making up the transaction.
+        /// </param>
+        /// <returns></returns>
+        async Task ISignatory.SignAsync(IInvoice invoice)
+        {
+            switch (_type)
+            {
+                case Type.Ed25519:
+                    var ed25519Key = (Key)_data;
+                    invoice.AddSignature(
+                        KeyType.Ed25519,
+                        ed25519Key.PublicKey.Export(KeyBlobFormat.PkixPublicKey).TakeLast(32).Take(6).ToArray(),
+                        SignatureAlgorithm.Ed25519.Sign(ed25519Key, invoice.TxBytes.Span));
+                    break;
+                case Type.List:
+                    foreach (ISignatory signer in (Signatory[])_data)
+                    {
+                        await signer.SignAsync(invoice);
+                    }
+                    break;
+                case Type.Callback:
+                    await ((Func<IInvoice, Task>)_data)(invoice);
+                    break;
+                case Type.OtherSigner:
+                    await ((ISignatory)_data).SignAsync(invoice);
+                    break;
+                default:
+                    throw new InvalidOperationException("Not a presently supported Signatory key type, please consider the callback signatory as an alternative.");
+            }
+        }
+    }
+}

--- a/test/Hashgraph.Test/AccountTests.cs
+++ b/test/Hashgraph.Test/AccountTests.cs
@@ -77,18 +77,27 @@ namespace Hashgraph.Tests
             Assert.StartsWith("Unable to create Account object, Private Key cannot be empty.", exception.Message);
         }
         [Fact(DisplayName = "Accounts: Empty Array of Private keys throws Exception")]
-        public void EmptyArrayOfKeysThrowsError()
+        public void EmptyArrayOfKeysSucceeds()
         {
             var realmNum = Generator.Integer(0, 200);
             var shardNum = Generator.Integer(0, 200);
             var accountNum = Generator.Integer(3, 200);
             var privateKeys = new ReadOnlyMemory<byte>[0];
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                new Account(realmNum, shardNum, accountNum, privateKeys);
-            });
-            Assert.Equal("privateKeys", exception.ParamName);
-            Assert.StartsWith("The Account object constructor was given no private signing keys, it requires least one (do you need an Address object instead?)", exception.Message);
+            using var account = new Account(realmNum, shardNum, accountNum, privateKeys);
+            Assert.Equal(realmNum, account.RealmNum);
+            Assert.Equal(shardNum, account.ShardNum);
+            Assert.Equal(accountNum, account.AccountNum);
+        }
+        [Fact(DisplayName = "Accounts: Constructor without keys succeeds.")]
+        public void ConstructorWithoutKeysSucceeds()
+        {
+            var realmNum = Generator.Integer(0, 200);
+            var shardNum = Generator.Integer(0, 200);
+            var accountNum = Generator.Integer(3, 200);
+            using var account = new Account(realmNum, shardNum, accountNum);
+            Assert.Equal(realmNum, account.RealmNum);
+            Assert.Equal(shardNum, account.ShardNum);
+            Assert.Equal(accountNum, account.AccountNum);
         }
         [Fact(DisplayName = "Accounts: Invalid Bytes in Private key throws Exception")]
         public void InvalidBytesForValueForKeyThrowsError()

--- a/test/Hashgraph.Test/Crypto/GetInfoTests.cs
+++ b/test/Hashgraph.Test/Crypto/GetInfoTests.cs
@@ -1,4 +1,5 @@
-﻿using Hashgraph.Test.Fixtures;
+﻿using System;
+using Hashgraph.Test.Fixtures;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -56,6 +57,47 @@ namespace Hashgraph.Test.Crypto
             Assert.True(info.ReceiveThresholdCreateRecord > 0);
             Assert.False(info.ReceiveSignatureRequired);
             Assert.True(info.AutoRenewPeriod.TotalSeconds > 0);
+        }
+        [Fact(DisplayName = "Get Account Info: Can Get Info for Account using Signatory")]
+        public async Task CanGetInfoForAccountUsingSignatory()
+        {
+            await using var client = _network.NewClient();
+            client.Configure(ctx => {
+                ctx.Payer = new Account(_network.Payer, null);
+                ctx.Signatory = _network.PrivateKey;
+            });
+            var account = _network.Payer;
+            var info = await client.GetAccountInfoAsync(account);
+            Assert.NotNull(info.Address);
+            Assert.Equal(account.RealmNum, info.Address.RealmNum);
+            Assert.Equal(account.ShardNum, info.Address.ShardNum);
+            Assert.Equal(account.AccountNum, info.Address.AccountNum);
+            Assert.NotNull(info.SmartContractId);
+            Assert.False(info.Deleted);
+            Assert.NotNull(info.Proxy);
+            Assert.Equal(new Address(0, 0, 0), info.Proxy);
+            Assert.Equal(0, info.ProxiedToAccount);
+            Assert.Equal(new Endorsement(_network.PublicKey), info.Endorsement);
+            Assert.True(info.Balance > 0);
+            Assert.True(info.SendThresholdCreateRecord > 0);
+            Assert.True(info.ReceiveThresholdCreateRecord > 0);
+            Assert.False(info.ReceiveSignatureRequired);
+            Assert.True(info.AutoRenewPeriod.TotalSeconds > 0);
+        }
+        [Fact(DisplayName = "Get Account Info: Getting Account Info without paying signature fails.")]
+        public async Task GetInfoWithoutPayingSignatureThrowsException()
+        {
+            await using var client = _network.NewClient();
+            client.Configure(ctx => {
+                ctx.Payer = new Account(_network.Payer, null);
+                ctx.Signatory = null;
+            });
+            var account = _network.Payer;
+            var ioe = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await client.GetAccountInfoAsync(account);
+            });
+            Assert.StartsWith("A transaction or query requires at least one signature, sometimes more.  None were found, did you forget to assign a Signatory to the context, transaction or query?", ioe.Message);
         }
     }
 }

--- a/test/Hashgraph.Test/SignatoryTests.cs
+++ b/test/Hashgraph.Test/SignatoryTests.cs
@@ -1,0 +1,156 @@
+﻿using Hashgraph.Test.Fixtures;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Hashgraph.Tests
+{
+    public class SignatoriesTests
+    {
+        [Fact(DisplayName = "Signatories: Can Create Valid Signatories Object")]
+        public void CreateValidSignatoriesObject()
+        {
+            var (_, privateKey1) = Generator.KeyPair();
+            var (_, privateKey2) = Generator.KeyPair();
+
+            new Signatory(privateKey1);
+            new Signatory(privateKey1, privateKey2);
+            new Signatory(new Signatory(privateKey1, privateKey2), new Signatory(privateKey1, privateKey2));
+        }
+        [Fact(DisplayName = "Signatories: Empty Private key throws Exception")]
+        public void EmptyValueForKeyThrowsError()
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                new Signatory();
+            });
+            Assert.Equal("signatories", exception.ParamName);
+            Assert.StartsWith("At least one Signatory in a list is required.", exception.Message);
+        }
+        [Fact(DisplayName = "Signatories: Invalid Bytes in Private key throws Exception")]
+        public void InvalidBytesForValueForKeyThrowsError()
+        {
+            var (_, originalKey) = Generator.KeyPair();
+            var invalidKey = originalKey.ToArray();
+            invalidKey[0] = 0;
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                new Signatory(KeyType.Ed25519, invalidKey);
+            });
+            Assert.StartsWith("The private key was not provided in a recognizable Ed25519 format.", exception.Message);
+        }
+        [Fact(DisplayName = "Signatories: Invalid Byte Length in Private key throws Exception")]
+        public void InvalidByteLengthForValueForKeyThrowsError()
+        {
+            var (_, originalKey) = Generator.KeyPair();
+            var invalidKey = originalKey.ToArray().Take(32).ToArray();
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                new Signatory(KeyType.Ed25519, invalidKey);
+            });
+            Assert.StartsWith("The private key was not provided in a recognizable Ed25519 format.", exception.Message);
+        }
+        [Fact(DisplayName = "Signatories: Equivalent Signatories are considered Equal")]
+        public void EquivalentSignatoriesAreConsideredEqual()
+        {
+            var (_, privateKey1) = Generator.KeyPair();
+            var (_, privateKey2) = Generator.KeyPair();
+            var signatory1 = new Signatory(privateKey1);
+            var signatory2 = new Signatory(privateKey1);
+            Assert.Equal(signatory1, signatory2);
+            Assert.True(signatory1 == signatory2);
+            Assert.False(signatory1 != signatory2);
+
+            signatory1 = new Signatory(privateKey1, privateKey2);
+            signatory2 = new Signatory(privateKey1, privateKey2);
+            Assert.Equal(signatory1, signatory2);
+            Assert.True(signatory1 == signatory2);
+            Assert.False(signatory1 != signatory2);
+        }
+        [Fact(DisplayName = "Signatories: Disimilar Signatories are not considered Equal")]
+        public void DisimilarSignatoriesAreNotConsideredEqual()
+        {
+            var (_, privateKey1) = Generator.KeyPair();
+            var (_, privateKey2) = Generator.KeyPair();
+            var signatory1 = new Signatory(privateKey1);
+            var signatory2 = new Signatory(privateKey2);
+            Assert.NotEqual(signatory1, signatory2);
+            Assert.False(signatory1 == signatory2);
+            Assert.True(signatory1 != signatory2);
+
+            signatory1 = new Signatory(privateKey1);
+            signatory2 = new Signatory(privateKey1, privateKey2);
+            Assert.NotEqual(signatory1, signatory2);
+            Assert.False(signatory1 == signatory2);
+            Assert.True(signatory1 != signatory2);
+
+            signatory1 = new Signatory(privateKey1, privateKey2);
+            signatory2 = new Signatory(privateKey2, privateKey1);
+            Assert.NotEqual(signatory1, signatory2);
+            Assert.False(signatory1 == signatory2);
+            Assert.True(signatory1 != signatory2);
+        }
+
+        [Fact(DisplayName = "Signatories: Disimilar Multi-Key Signatories are not considered Equal")]
+        public void DisimilarMultiKeySignatoriesAreNotConsideredEqual()
+        {
+            var (_, privateKey1) = Generator.KeyPair();
+            var (_, privateKey2) = Generator.KeyPair();
+            var (_, privateKey3) = Generator.KeyPair();
+            var signatories1 = new Signatory(privateKey1, privateKey2);
+            var signatories2 = new Signatory(privateKey2, privateKey3);
+            Assert.NotEqual(signatories1, signatories2);
+            Assert.False(signatories1 == signatories2);
+            Assert.True(signatories1 != signatories2);
+
+            signatories1 = new Signatory(privateKey1, privateKey2, privateKey3);
+            signatories2 = new Signatory(privateKey1, privateKey2);
+            Assert.NotEqual(signatories1, signatories2);
+            Assert.False(signatories1 == signatories2);
+            Assert.True(signatories1 != signatories2);
+
+            signatories1 = new Signatory(privateKey2, privateKey3, privateKey1);
+            signatories2 = new Signatory(privateKey1, privateKey2, privateKey3);
+            Assert.NotEqual(signatories1, signatories2);
+            Assert.False(signatories1 == signatories2);
+            Assert.True(signatories1 != signatories2);
+        }
+        [Fact(DisplayName = "Signatories: Equivalent Complex Signatories are considered Equal")]
+        public void EquivalentComplexSignatoriesAreConsideredEqual()
+        {
+            Func<IInvoice,Task> callback = ctx => { return Task.FromResult(0); };
+            var (_, privateKey1) = Generator.KeyPair();
+            var (_, privateKey2) = Generator.KeyPair();
+            var (_, privateKey3) = Generator.KeyPair();
+            var signatory1 = new Signatory(callback);
+            var signatory2 = new Signatory(callback);
+            Assert.Equal(signatory1, signatory2);
+            Assert.True(signatory1 == signatory2);
+            Assert.False(signatory1 != signatory2);
+
+            signatory1 = new Signatory(privateKey1, new Signatory(callback));
+            signatory2 = new Signatory(privateKey1, callback);
+            Assert.Equal(signatory1, signatory2);
+            Assert.True(signatory1 == signatory2);
+            Assert.False(signatory1 != signatory2);
+            signatory1 = new Signatory(privateKey1, callback, new Signatory(privateKey2,privateKey3));
+            signatory2 = new Signatory(privateKey1, callback, new Signatory(privateKey2, privateKey3));
+            Assert.Equal(signatory1, signatory2);
+            Assert.True(signatory1 == signatory2);
+            Assert.False(signatory1 != signatory2);
+        }
+        [Fact(DisplayName = "Signatories: Only Reference Equal Callbacks are considered Equal")]
+        public void CallbackSignatoriesAreOnlyReferenceEqual()
+        {
+            Func<IInvoice, Task> callback1 = ctx => { return Task.FromResult(0); };
+            Func<IInvoice, Task> callback2 = ctx => { return Task.FromResult(0); };
+
+            var signatory1 = new Signatory(callback1);
+            var signatory2 = new Signatory(callback2);
+            Assert.NotEqual(signatory1, signatory2);
+            Assert.False(signatory1 == signatory2);
+            Assert.True(signatory1 != signatory2);
+        }
+    }
+}


### PR DESCRIPTION
Introduced a new object to the library called a Signatory.  This object
can hold a private key and can sign a transaction on behalf of the key
owner or it can be given a callback method that can sign a given network
transaction prior to the library submitting it to the network.  This is
now the preferred way to facilitate transaction signing.  This
functionality supersedes the original design decision associated to
place private keys inside the Account object.  The Account object no
longer need be instantiated with any private keys.  Eventually the
Account object will be deprecated and replaced with Address objects in a
future release (presently targeted for removal in version 4.0.0).