### PR TITLE
Fixes #125 Depricate Account

### DIFF
--- a/src/Hashgraph/Account.cs
+++ b/src/Hashgraph/Account.cs
@@ -1,5 +1,4 @@
-﻿using Google.Protobuf;
-using Hashgraph.Implementation;
+﻿using Hashgraph.Implementation;
 using NSec.Cryptography;
 using System;
 using System.Linq;
@@ -29,6 +28,15 @@ namespace Hashgraph
         /// Private Key Implementation
         /// </summary>
         private readonly Key[] _keys;
+#pragma warning disable CS0618 // Type or member is obsolete
+        /// <summary>
+        /// Public Constructor, an <code>Account</code> is immutable after creation.
+        /// </summary>
+        /// <param name="address">
+        /// Network Address associated with this account.
+        /// </param>
+        public Account(Address address) : this(address.RealmNum, address.ShardNum, address.AccountNum, new ReadOnlyMemory<byte>[0]) { }
+#pragma warning restore CS0618 // Type or member is obsolete
         /// <summary>
         /// Public Constructor, an <code>Account</code> is immutable after creation.
         /// </summary>
@@ -40,7 +48,23 @@ namespace Hashgraph
         /// signing transactions.  It is expected to be 48 bytes in length, prefixed 
         /// with <code>0x302e020100300506032b6570</code>.
         /// </param>
+        [Obsolete("Please use Signatory object to hold private keys instead of the Account Object, The Account object will be replaced with the Address object in a future release.")]
         public Account(Address address, params ReadOnlyMemory<byte>[] privateKeys) : this(address.RealmNum, address.ShardNum, address.AccountNum, privateKeys) { }
+#pragma warning disable CS0618 // Type or member is obsolete
+        /// <summary>
+        /// Public Constructor, an <code>Account</code> is immutable after creation.
+        /// </summary>
+        /// <param name="realmNum">
+        /// Network Realm Number
+        /// </param>
+        /// <param name="shardNum">
+        /// Network Shard Number
+        /// </param>
+        /// <param name="accountNum">
+        /// Network Account Number
+        /// </param>
+        public Account(long realmNum, long shardNum, long accountNum) : this(realmNum, shardNum, accountNum, new ReadOnlyMemory<byte>[0]) { }
+#pragma warning restore CS0618 // Type or member is obsolete
         /// <summary>
         /// Public Constructor, an <code>Account</code> is immutable after creation.
         /// </summary>
@@ -58,6 +82,7 @@ namespace Hashgraph
         /// signing transactions.  It is expected to be 48 bytes in length, prefixed 
         /// with <code>0x302e020100300506032b6570</code>.
         /// </param>
+        [Obsolete("Please use Signatory object to hold private keys instead of the Account Object, The Account object will be replaced with the Address object in a future release.")]
         public Account(long realmNum, long shardNum, long accountNum, params ReadOnlyMemory<byte>[] privateKeys)
         {
             RealmNum = RequireInputParameter.RealmNumber(realmNum);
@@ -78,7 +103,7 @@ namespace Hashgraph
         /// </param>
         Task ISignatory.SignAsync(IInvoice invoice)
         {
-            foreach(var key in _keys)
+            foreach (var key in _keys)
             {
                 invoice.AddSignature(
                     KeyType.Ed25519,

--- a/src/Hashgraph/Address.cs
+++ b/src/Hashgraph/Address.cs
@@ -82,7 +82,7 @@ namespace Hashgraph
             {
                 return true;
             }
-            if (obj is Account other)
+            if (obj is Address other)
             {
                 return Equals(other);
             }

--- a/src/Hashgraph/ExchangeRate.cs
+++ b/src/Hashgraph/ExchangeRate.cs
@@ -81,7 +81,7 @@ namespace Hashgraph
             {
                 return true;
             }
-            if (obj is Account other)
+            if (obj is ExchangeRate other)
             {
                 return Equals(other);
             }

--- a/src/Hashgraph/Implementation/Epoch.cs
+++ b/src/Hashgraph/Implementation/Epoch.cs
@@ -21,13 +21,10 @@ namespace Hashgraph.Implementation
             for (int i = 0; i < 1000; i++)
             {
                 var nanos = (DateTime.UtcNow - EPOCH).Ticks * NanosPerTick;
-                if (nanos > Interlocked.Read(ref _previousNano))
+                var previousNano = Interlocked.Exchange(ref _previousNano, nanos);
+                if (nanos > previousNano)
                 {
-                    var previousNano = Interlocked.Exchange(ref _previousNano, nanos);
-                    if (nanos > previousNano)
-                    {
-                        return nanos;
-                    }
+                    return nanos;
                 }
                 Thread.Yield();
             }

--- a/src/Hashgraph/Implementation/RequireInputParameter.cs
+++ b/src/Hashgraph/Implementation/RequireInputParameter.cs
@@ -38,13 +38,13 @@ namespace Hashgraph.Implementation
             return smartContractId;
         }
 
-        internal static Account AccountToDelete(Account accountToDelete)
+        internal static Address AddressToDelete(Address addressToDelete)
         {
-            if (accountToDelete is null)
+            if (addressToDelete is null)
             {
-                throw new ArgumentNullException(nameof(accountToDelete), "Account to Delete is missing. Please check that it is not null.");
+                throw new ArgumentNullException(nameof(addressToDelete), "Address to Delete is missing. Please check that it is not null.");
             }
-            return accountToDelete;
+            return addressToDelete;
         }
         internal static Address File(Address file)
         {
@@ -89,6 +89,14 @@ namespace Hashgraph.Implementation
             return fromAccount;
         }
 
+        internal static Address FromAddress(Address fromAddress)
+        {
+            if (fromAddress is null)
+            {
+                throw new ArgumentNullException(nameof(fromAddress), "Address to transfer from is missing. Please check that it is not null.");
+            }
+            return fromAddress;
+        }
         internal static Address ToAddress(Address toAddress)
         {
             if (toAddress is null)
@@ -104,6 +112,27 @@ namespace Hashgraph.Implementation
                 throw new ArgumentOutOfRangeException(nameof(amount), "The amount to transfer must be non-negative.");
             }
             return amount;
+        }
+        internal static (Address address, long amount)[] TransferList(Dictionary<Address,long> transfers)
+        {
+            if(transfers is null)
+            {
+                throw new ArgumentNullException(nameof(transfers), "The dictionary of transfers can not be null.");
+            }
+            if(transfers.Count == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(transfers), "The dictionary of transfers can not be empty.");
+            }
+            var result = new List<(Address address, long amount)>();
+            foreach(var transfer in transfers)
+            {
+                if(transfer.Value == 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(transfers), $"The amount to transfer to/from {transfer.Key.RealmNum}.{transfer.Key.ShardNum}.{transfer.Key.AccountNum} must be a value, negative for transfers out, and positive for transfers in. A value of zero is not allowed.");
+                }
+                result.Add((transfer.Key, transfer.Value));
+            }
+            return result.ToArray();
         }
         internal static TxId Transaction(TxId transaction)
         {

--- a/src/Hashgraph/Implementation/Transactions.cs
+++ b/src/Hashgraph/Implementation/Transactions.cs
@@ -16,15 +16,21 @@ namespace Hashgraph
     /// </summary>
     internal static class Transactions
     {
-        internal static Signatory GatherSignatories(ContextStack context, params Signatory[] extraSignatories)
+        internal static Signatory GatherSignatories(ContextStack context, params Signatory?[] extraSignatories)
         {
             var signatories = new List<Signatory>(1 + extraSignatories.Length);
-            var signatory = context.Signatory;
-            if (!(signatory is null))
+            var contextSignatory = context.Signatory;
+            if (!(contextSignatory is null))
             {
-                signatories.Add(signatory);
+                signatories.Add(contextSignatory);
             }
-            signatories.AddRange(extraSignatories);
+            foreach(var extraSignatory in extraSignatories)
+            {
+                if(!(extraSignatory is null))
+                {
+                    signatories.Add(extraSignatory);
+                }
+            }
             return signatories.Count == 1 ?
                 signatories[0] :
                 new Signatory(signatories.ToArray());

--- a/test/Hashgraph.Test/Claims/AddClaimTests.cs
+++ b/test/Hashgraph.Test/Claims/AddClaimTests.cs
@@ -36,7 +36,7 @@ namespace Hashgraph.Test.Claims
 
                 var receipt = await test.Client.AddClaimAsync(claim, ctx =>
                 {
-                    ctx.Payer = _network.PayerWithKeys(privateKey1, privateKey2);
+                    ctx.Signatory = new Signatory(ctx.Signatory, privateKey1, privateKey2);
                 });
                 Assert.Equal(ResponseCode.Success, receipt.Status);
             }

--- a/test/Hashgraph.Test/Contract/DeleteContractTests.cs
+++ b/test/Hashgraph.Test/Contract/DeleteContractTests.cs
@@ -59,7 +59,7 @@ namespace Hashgraph.Test.Contract
             var (publicKey, privateKey) = Generator.KeyPair();
             await using var fx = await GreetingContract.SetupAsync(_network);
             fx.ContractParams.Administrator = publicKey;  // Default is to use Payor's
-            fx.Client.Configure(ctx => ctx.Payer = _network.PayerWithKeys(privateKey));
+            fx.Client.Configure(ctx => ctx.Signatory = new Signatory(ctx.Signatory, privateKey));
             await fx.CompleteCreateAsync();
 
             await using (var client = _network.NewClient())  // Will not have private key

--- a/test/Hashgraph.Test/Contract/UpdateContractTests.cs
+++ b/test/Hashgraph.Test/Contract/UpdateContractTests.cs
@@ -22,9 +22,9 @@ namespace Hashgraph.Test.Contract
             var (newPublicKey, newPrivateKey) = Generator.KeyPair();
             var newExpiration = Generator.TruncatedFutureDate(2400, 4800);
             var newEndorsement = new Endorsement(newPublicKey);
-            var updatedPayer = _network.PayerWithKeys(newPrivateKey);
+            var updatedSignatory = new Signatory(_network.Signatory, newPrivateKey);
             var newMemo = Generator.Code(50);
-            fx.Client.Configure(ctx => ctx.Payer = updatedPayer);
+            fx.Client.Configure(ctx => ctx.Signatory = updatedSignatory);
             var record = await fx.Client.UpdateContractWithRecordAsync(new UpdateContractParams
             {
                 Contract = fx.ContractRecord.Contract,
@@ -49,10 +49,10 @@ namespace Hashgraph.Test.Contract
             var (newPublicKey, newPrivateKey) = Generator.KeyPair();
             var newExpiration = Generator.TruncatedFutureDate(2400, 4800);
             var newEndorsement = new Endorsement(newPublicKey);
-            var updatedPayer = _network.PayerWithKeys(newPrivateKey);
+            var updatedSignatory = new Signatory(_network.Signatory, newPrivateKey);
             var newRenewPeriod = TimeSpan.FromDays(Generator.Integer(180, 365));
             var newMemo = Generator.Code(50);
-            fx.Client.Configure(ctx => ctx.Payer = updatedPayer);
+            fx.Client.Configure(ctx => ctx.Signatory = updatedSignatory);
             var pex = await Assert.ThrowsAsync<PrecheckException>(async () =>
             {
                 var record = await fx.Client.UpdateContractWithRecordAsync(new UpdateContractParams
@@ -105,8 +105,8 @@ namespace Hashgraph.Test.Contract
             await using var fx = await GreetingContract.CreateAsync(_network);
             var (newPublicKey, newPrivateKey) = Generator.KeyPair();
             var newEndorsement = new Endorsement(newPublicKey);
-            var updatedPayer = _network.PayerWithKeys(newPrivateKey);
-            fx.Client.Configure(ctx => ctx.Payer = updatedPayer);
+            var updatedSignatory = new Signatory(_network.Signatory, newPrivateKey);
+            fx.Client.Configure(ctx => ctx.Signatory = updatedSignatory);
             var record = await fx.Client.UpdateContractWithRecordAsync(new UpdateContractParams
             {
                 Contract = fx.ContractRecord.Contract,
@@ -218,12 +218,12 @@ namespace Hashgraph.Test.Contract
             var (publicKey, privateKey) = Generator.KeyPair();
             await using var fx = await GreetingContract.SetupAsync(_network);
             fx.ContractParams.Administrator = publicKey;
-            fx.Client.Configure(ctx => ctx.Payer = new Account(ctx.Payer, _network.PrivateKey, privateKey));
+            fx.Client.Configure(ctx => ctx.Signatory = new Signatory(ctx.Signatory, privateKey));
             await fx.CompleteCreateAsync();
             // First, Remove admin key from Payer's Account
             var tex = await Assert.ThrowsAsync<TransactionException>(async () =>
             {
-                fx.Client.Configure(ctx => ctx.Payer = new Account(ctx.Payer, _network.PrivateKey));
+                fx.Client.Configure(ctx => ctx.Signatory = new Signatory(_network.PrivateKey));
                 await fx.Client.UpdateContractWithRecordAsync(new UpdateContractParams
                 {
                     Contract = fx.ContractRecord.Contract,

--- a/test/Hashgraph.Test/Crypto/AccountMultisigTests.cs
+++ b/test/Hashgraph.Test/Crypto/AccountMultisigTests.cs
@@ -195,7 +195,7 @@ namespace Hashgraph.Test.Crypto
                 Endorsement = publicKey3
             }, ctx =>
             {
-                ctx.Payer = _network.PayerWithKeys(privateKey1a, privateKey2a);
+                ctx.Signatory = new Signatory(_network.Signatory, privateKey1a, privateKey2a);
             });
 
             // Now try with proper set of signatures

--- a/test/Hashgraph.Test/Crypto/GetAccountBalanceTests.cs
+++ b/test/Hashgraph.Test/Crypto/GetAccountBalanceTests.cs
@@ -35,7 +35,7 @@ namespace Hashgraph.Test.Crypto
         public async Task MissingNodeInformationThrowsException()
         {
             var account = _network.Payer;
-            await using var client = new Client(ctx => { ctx.Payer = account; });
+            await using var client = new Client(ctx => { ctx.Payer = _network.PayerAsAccountWithPrivateKey; });
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 var balance = await client.GetAccountBalanceAsync(account);

--- a/test/Hashgraph.Test/Crypto/TransferTests.cs
+++ b/test/Hashgraph.Test/Crypto/TransferTests.cs
@@ -129,7 +129,7 @@ namespace Hashgraph.Test.Crypto
             var account2 = new Account(fx2.Record.Address, fx2.PrivateKey);
             var transferAmount = (long)Generator.Integer(100, 200);
 
-            var sendAccounts = new Dictionary<Account, long> { { payer, 2 * transferAmount } };
+            var sendAccounts = new Dictionary<Account, long> { {_network.PayerAsAccountWithPrivateKey, 2 * transferAmount } };
             var receiveAddresses = new Dictionary<Address, long> { { account1, transferAmount }, { account2, transferAmount } };
 
             var sendRecord = await fx1.Client.TransferWithRecordAsync(sendAccounts, receiveAddresses);
@@ -156,7 +156,7 @@ namespace Hashgraph.Test.Crypto
             var account2 = new Account(fx2.Record.Address, fx2.PrivateKey);
             var transferAmount = (long)Generator.Integer(100, 200);
 
-            var sendAccounts = new Dictionary<Account, long> { { payer, transferAmount } };
+            var sendAccounts = new Dictionary<Account, long> { { _network.PayerAsAccountWithPrivateKey, transferAmount } };
             var receiveAddresses = new Dictionary<Address, long> { { account1, transferAmount }, { account2, transferAmount } };
 
             var aor = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
@@ -176,7 +176,7 @@ namespace Hashgraph.Test.Crypto
             var account2 = new Account(fx2.Record.Address, fx2.PrivateKey);
             var transferAmount = (long)Generator.Integer(100, 200);
 
-            var sendAccounts = new Dictionary<Account, long> { { payer, 3 * transferAmount } };
+            var sendAccounts = new Dictionary<Account, long> { { _network.PayerAsAccountWithPrivateKey, 3 * transferAmount } };
             var receiveAddresses = new Dictionary<Address, long> { { account1, transferAmount }, { account2, transferAmount }, { payer, transferAmount } };
 
             var sendRecord = await fx1.Client.TransferWithRecordAsync(sendAccounts, receiveAddresses, ctx => ctx.FeeLimit = 1_000_000);
@@ -185,7 +185,7 @@ namespace Hashgraph.Test.Crypto
             Assert.Equal((ulong)transferAmount + fx1.CreateParams.InitialBalance, await fx1.Client.GetAccountBalanceAsync(account1));
             Assert.Equal((ulong)transferAmount + fx2.CreateParams.InitialBalance, await fx2.Client.GetAccountBalanceAsync(account2));
 
-            sendAccounts = new Dictionary<Account, long> { { account1, transferAmount }, { account2, transferAmount }, { payer, transferAmount } };
+            sendAccounts = new Dictionary<Account, long> { { account1, transferAmount }, { account2, transferAmount }, { _network.PayerAsAccountWithPrivateKey, transferAmount } };
             receiveAddresses = new Dictionary<Address, long> { { payer, 3 * transferAmount } };
             var returnRecord = await fx1.Client.TransferWithRecordAsync(sendAccounts, receiveAddresses, ctx => ctx.FeeLimit = 1_000_000);
             Assert.Equal(ResponseCode.Success, returnRecord.Status);

--- a/test/Hashgraph.Test/Fixtures/GreetingContract.cs
+++ b/test/Hashgraph.Test/Fixtures/GreetingContract.cs
@@ -7,6 +7,7 @@ namespace Hashgraph.Test.Fixtures
 {
     public class GreetingContract : IAsyncDisposable
     {
+        public string TestInstanceId;
         public string Memo;
         public Client Client;
         public CreateFileParams FileParams;
@@ -44,7 +45,8 @@ namespace Hashgraph.Test.Fixtures
         {
             var fx = new GreetingContract();
             fx.Network = networkCredentials;
-            fx.Memo = "Greeting Contract Create: Instantiating Contract Instance " + Generator.Code(10);
+            fx.TestInstanceId = Generator.Code(10);
+            fx.Memo = "Greeting Contract Create: Instantiating Contract Instance " + fx.TestInstanceId;
             fx.FileParams = new CreateFileParams
             {
                 Expiration = DateTime.UtcNow.AddSeconds(7890000),
@@ -54,7 +56,7 @@ namespace Hashgraph.Test.Fixtures
             fx.Client = networkCredentials.NewClient();
             fx.FileRecord = await fx.Client.CreateFileWithRecordAsync(fx.FileParams, ctx =>
             {
-                ctx.Memo = "Greeting Contract Create: Uploading Contract File " + Generator.Code(10);
+                ctx.Memo = "Greeting Contract Create: Uploading Contract File " + fx.TestInstanceId;
             });
             Assert.Equal(ResponseCode.Success, fx.FileRecord.Status);
             fx.ContractParams = new CreateContractParams
@@ -81,11 +83,11 @@ namespace Hashgraph.Test.Fixtures
             {
                 await Client.DeleteFileAsync(FileRecord.File, ctx =>
                 {
-                    ctx.Memo = "Greeting Contract Teardown: Delete Contract File (may already be deleted)";
+                    ctx.Memo = "Greeting Contract Teardown: Delete Contract File (may already be deleted) " + TestInstanceId;
                 });
                 await Client.DeleteContractAsync(ContractRecord.Contract, Network.Payer, ctx =>
                 {
-                    ctx.Memo = "Greeting Contract Teardown: Delete Contract (may already be deleted)";
+                    ctx.Memo = "Greeting Contract Teardown: Delete Contract (may already be deleted) " + TestInstanceId;
                 });
             }
             catch

--- a/test/Hashgraph.Test/Fixtures/TestFile.cs
+++ b/test/Hashgraph.Test/Fixtures/TestFile.cs
@@ -12,7 +12,8 @@ namespace Hashgraph.Test.Fixtures
         public ReadOnlyMemory<byte> PublicKey;
         public ReadOnlyMemory<byte> PrivateKey;
         public DateTime Expiration;
-        public Account Payer;
+        public Address Payer;
+        public Signatory Signatory;
         public Client Client;
         public FileRecord Record;
         public NetworkCredentials Network;
@@ -25,9 +26,10 @@ namespace Hashgraph.Test.Fixtures
             test.Contents = Encoding.Unicode.GetBytes("Hello From .NET" + Generator.Code(50)).Take(48).ToArray();
             (test.PublicKey, test.PrivateKey) = Generator.KeyPair();
             test.Expiration = Generator.TruncateToSeconds(DateTime.UtcNow.AddSeconds(7890000));
-            test.Payer = networkCredentials.PayerWithKeys(networkCredentials.PrivateKey, test.PrivateKey);
+            test.Payer = networkCredentials.Payer;
+            test.Signatory = new Signatory(networkCredentials.Signatory, test.PrivateKey);
             test.Client = networkCredentials.NewClient();
-            test.Client.Configure(ctx => { ctx.Payer = test.Payer; });
+            test.Client.Configure(ctx => { ctx.Signatory = test.Signatory; });
             test.Record = await test.Client.CreateFileWithRecordAsync(new CreateFileParams
             {
                 Expiration = test.Expiration,

--- a/test/Hashgraph.Test/Record/GetAccountRecordTests.cs
+++ b/test/Hashgraph.Test/Record/GetAccountRecordTests.cs
@@ -30,7 +30,7 @@ namespace Hashgraph.Test.Record
             {
                 for (int i = 0; i < transactionCount; i++)
                 {
-                    await client.TransferWithRecordAsync(childAccount, parentAccount, transferAmount);
+                    await client.TransferAsync(childAccount, parentAccount, transferAmount);
                 }
             }
             var records = await fxAccount.Client.GetAccountRecordsAsync(childAccount);


### PR DESCRIPTION
Depricated the Account object constructor and
and many of the Client API methods accepting the
Account object as a parameter.  Added new API
calls accepting Addresses and Signatories in the
place of the Account object.  The depricated
API calls will be removed in the next major release.