### PR TITLE
Modifications for TESTNET Compatibility

### DIFF
--- a/src/Hashgraph/Contract/CallContract.cs
+++ b/src/Hashgraph/Contract/CallContract.cs
@@ -33,9 +33,9 @@ namespace Hashgraph
         /// <exception cref="PrecheckException">If the gateway node create rejected the request upon submission.</exception>
         /// <exception cref="ConsensusException">If the network was unable to come to consensus before the duration of the transaction expired.</exception>
         /// <exception cref="TransactionException">If the network rejected the create request as invalid or had missing data.</exception>
-        public Task<ContractReceipt> CallContractAsync(CallContractParams callParameters, Action<IContext>? configure = null)
+        public Task<TransactionReceipt> CallContractAsync(CallContractParams callParameters, Action<IContext>? configure = null)
         {
-            return CallContractImplementationAsync<ContractReceipt>(callParameters, configure);
+            return CallContractImplementationAsync<TransactionReceipt>(callParameters, configure);
         }
         /// <summary>
         /// Calls a smart contract returning if successful.  The CallContractReceipt 
@@ -96,13 +96,11 @@ namespace Hashgraph
             {
                 var record = await GetTransactionRecordAsync(context, transactionId);
                 Protobuf.FillRecordProperties(record, rec);
-                rec.Contract = Protobuf.FromContractID(record.Receipt.ContractID);
                 rec.CallResult = Protobuf.FromContractCallResult(record.ContractCallResult);
             }
-            else if (result is ContractReceipt rcpt)
+            else if (result is TransactionReceipt rcpt)
             {
                 Protobuf.FillReceiptProperties(transactionId, receipt, rcpt);
-                rcpt.Contract = Protobuf.FromContractID(receipt.ContractID);
             }
             return result;
 

--- a/src/Hashgraph/Contract/CallContractRecord.cs
+++ b/src/Hashgraph/Contract/CallContractRecord.cs
@@ -8,10 +8,6 @@ namespace Hashgraph
     public sealed class CallContractRecord : TransactionRecord
     {
         /// <summary>
-        /// The address of the contract.
-        /// </summary>
-        public Address Contract { get; internal set; }
-        /// <summary>
         /// The results returned from the contract call.
         /// </summary>
         public ContractCallResult CallResult { get; internal set; }

--- a/src/Hashgraph/Contract/CreateContract.cs
+++ b/src/Hashgraph/Contract/CreateContract.cs
@@ -29,9 +29,9 @@ namespace Hashgraph
         /// <exception cref="PrecheckException">If the gateway node create rejected the request upon submission.</exception>
         /// <exception cref="ConsensusException">If the network was unable to come to consensus before the duration of the transaction expired.</exception>
         /// <exception cref="TransactionException">If the network rejected the create request as invalid or had missing data.</exception>
-        public Task<ContractReceipt> CreateContractAsync(CreateContractParams createParameters, Action<IContext>? configure = null)
+        public Task<CreateContractReceipt> CreateContractAsync(CreateContractParams createParameters, Action<IContext>? configure = null)
         {
-            return CreateContractImplementationAsync<ContractReceipt>(createParameters, configure);
+            return CreateContractImplementationAsync<CreateContractReceipt>(createParameters, configure);
         }
         /// <summary>
         /// Creates a new contract instance with the given create parameters 
@@ -54,9 +54,9 @@ namespace Hashgraph
         /// <exception cref="PrecheckException">If the gateway node create rejected the request upon submission.</exception>
         /// <exception cref="ConsensusException">If the network was unable to come to consensus before the duration of the transaction expired.</exception>
         /// <exception cref="TransactionException">If the network rejected the create request as invalid or had missing data.</exception>
-        public Task<ContractRecord> CreateContractWithRecordAsync(CreateContractParams createParameters, Action<IContext>? configure = null)
+        public Task<CreateContractRecord> CreateContractWithRecordAsync(CreateContractParams createParameters, Action<IContext>? configure = null)
         {
-            return CreateContractImplementationAsync<ContractRecord>(createParameters, configure);
+            return CreateContractImplementationAsync<CreateContractRecord>(createParameters, configure);
         }
         /// <summary>
         /// Internal Create Contract Implementation
@@ -89,13 +89,13 @@ namespace Hashgraph
                 throw new TransactionException($"Unable to create contract, status: {receipt.Status}", Protobuf.FromTransactionId(transactionId), (ResponseCode)receipt.Status);
             }
             var result = new TResult();
-            if (result is ContractRecord rec)
+            if (result is CreateContractRecord rec)
             {
                 var record = await GetTransactionRecordAsync(context, transactionId);
                 Protobuf.FillRecordProperties(record, rec);
                 rec.Contract = Protobuf.FromContractID(receipt.ContractID);
             }
-            else if (result is ContractReceipt rcpt)
+            else if (result is CreateContractReceipt rcpt)
             {
                 Protobuf.FillReceiptProperties(transactionId, receipt, rcpt);
                 rcpt.Contract = Protobuf.FromContractID(receipt.ContractID);

--- a/src/Hashgraph/Contract/CreateContractReceipt.cs
+++ b/src/Hashgraph/Contract/CreateContractReceipt.cs
@@ -5,7 +5,7 @@ namespace Hashgraph
     /// <summary>
     /// Receipt produced from creating a new contract.
     /// </summary>
-    public sealed class ContractReceipt : TransactionReceipt
+    public sealed class CreateContractReceipt : TransactionReceipt
     {
         /// <summary>
         /// The newly created or associated contract instance address.

--- a/src/Hashgraph/Contract/CreateContractRecord.cs
+++ b/src/Hashgraph/Contract/CreateContractRecord.cs
@@ -5,7 +5,7 @@ namespace Hashgraph
     /// <summary>
     /// Record produced from creating a new contract.
     /// </summary>
-    public sealed class ContractRecord : TransactionRecord
+    public sealed class CreateContractRecord : TransactionRecord
     {
         /// <summary>
         /// The newly created contract instance address.

--- a/src/Hashgraph/Crypto/CreateAccount.cs
+++ b/src/Hashgraph/Crypto/CreateAccount.cs
@@ -29,9 +29,9 @@ namespace Hashgraph
         /// <exception cref="PrecheckException">If the gateway node create rejected the request upon submission.</exception>
         /// <exception cref="ConsensusException">If the network was unable to come to consensus before the duration of the transaction expired.</exception>
         /// <exception cref="TransactionException">If the network rejected the create request as invalid or had missing data.</exception>
-        public Task<AccountReceipt> CreateAccountAsync(CreateAccountParams createParameters, Action<IContext>? configure = null)
+        public Task<CreateAccountReceipt> CreateAccountAsync(CreateAccountParams createParameters, Action<IContext>? configure = null)
         {
-            return CreateAccountImplementationAsync<AccountReceipt>(createParameters, configure);
+            return CreateAccountImplementationAsync<CreateAccountReceipt>(createParameters, configure);
         }
         /// <summary>
         /// Creates a new network account with a given initial balance
@@ -55,9 +55,9 @@ namespace Hashgraph
         /// <exception cref="PrecheckException">If the gateway node create rejected the request upon submission.</exception>
         /// <exception cref="ConsensusException">If the network was unable to come to consensus before the duration of the transaction expired.</exception>
         /// <exception cref="TransactionException">If the network rejected the create request as invalid or had missing data.</exception>
-        public Task<AccountRecord> CreateAccountWithRecordAsync(CreateAccountParams createParameters, Action<IContext>? configure = null)
+        public Task<CreateAccountRecord> CreateAccountWithRecordAsync(CreateAccountParams createParameters, Action<IContext>? configure = null)
         {
-            return CreateAccountImplementationAsync<AccountRecord>(createParameters, configure);
+            return CreateAccountImplementationAsync<CreateAccountRecord>(createParameters, configure);
         }
         /// <summary>
         /// Internal implementation for Create Account
@@ -92,16 +92,16 @@ namespace Hashgraph
                 throw new TransactionException($"Unable to create account, status: {receipt.Status}", Protobuf.FromTransactionId(transactionId), (ResponseCode)receipt.Status);
             }
             var result = new TResult();
-            if (result is AccountReceipt arcpt)
-            {
-                Protobuf.FillReceiptProperties(transactionId, receipt, arcpt);
-                arcpt.Address = Protobuf.FromAccountID(receipt.AccountID);
-            }
-            else if (result is AccountRecord arec)
+            if (result is CreateAccountRecord arec)
             {
                 var record = await GetTransactionRecordAsync(context, transactionId);
                 Protobuf.FillRecordProperties(record, arec);
                 arec.Address = Protobuf.FromAccountID(receipt.AccountID);
+            }
+            else if (result is CreateAccountReceipt arcpt)
+            {
+                Protobuf.FillReceiptProperties(transactionId, receipt, arcpt);
+                arcpt.Address = Protobuf.FromAccountID(receipt.AccountID);
             }
             return result;
 

--- a/src/Hashgraph/Crypto/CreateAccountReceipt.cs
+++ b/src/Hashgraph/Crypto/CreateAccountReceipt.cs
@@ -5,7 +5,7 @@ namespace Hashgraph
     /// <summary>
     /// A transaction record containing information concerning the newly created account.
     /// </summary>
-    public sealed class AccountReceipt : TransactionReceipt
+    public sealed class CreateAccountReceipt : TransactionReceipt
     {
         /// <summary>
         /// The address of the newly created account.

--- a/src/Hashgraph/Crypto/CreateAccountRecord.cs
+++ b/src/Hashgraph/Crypto/CreateAccountRecord.cs
@@ -5,7 +5,7 @@ namespace Hashgraph
     /// <summary>
     /// A transaction record containing information concerning the newly created account.
     /// </summary>
-    public sealed class AccountRecord : TransactionRecord
+    public sealed class CreateAccountRecord : TransactionRecord
     {
         /// <summary>
         /// The address of the newly created account.

--- a/src/Hashgraph/Crypto/UpdateAccount.cs
+++ b/src/Hashgraph/Crypto/UpdateAccount.cs
@@ -30,9 +30,9 @@ namespace Hashgraph
         /// <exception cref="PrecheckException">If the gateway node create rejected the request upon submission.</exception>
         /// <exception cref="ConsensusException">If the network was unable to come to consensus before the duration of the transaction expired.</exception>
         /// <exception cref="TransactionException">If the network rejected the create request as invalid or had missing data.</exception>
-        public Task<AccountReceipt> UpdateAccountAsync(UpdateAccountParams updateParameters, Action<IContext>? configure = null)
+        public Task<TransactionReceipt> UpdateAccountAsync(UpdateAccountParams updateParameters, Action<IContext>? configure = null)
         {
-            return UpdateAccountImplementationAsync<AccountReceipt>(updateParameters, configure);
+            return UpdateAccountImplementationAsync<TransactionReceipt>(updateParameters, configure);
         }
         /// <summary>
         /// Updates the changeable properties of a hedera network account.
@@ -56,9 +56,9 @@ namespace Hashgraph
         /// <exception cref="PrecheckException">If the gateway node create rejected the request upon submission.</exception>
         /// <exception cref="ConsensusException">If the network was unable to come to consensus before the duration of the transaction expired.</exception>
         /// <exception cref="TransactionException">If the network rejected the create request as invalid or had missing data.</exception>
-        public Task<AccountRecord> UpdateAccountWithRecordAsync(UpdateAccountParams updateParameters, Action<IContext>? configure = null)
+        public Task<TransactionRecord> UpdateAccountWithRecordAsync(UpdateAccountParams updateParameters, Action<IContext>? configure = null)
         {
-            return UpdateAccountImplementationAsync<AccountRecord>(updateParameters, configure);
+            return UpdateAccountImplementationAsync<TransactionRecord>(updateParameters, configure);
         }
         /// <summary>
         /// Internal implementation of the update account functionality.
@@ -110,16 +110,14 @@ namespace Hashgraph
                 throw new TransactionException($"Unable to update account, status: {receipt.Status}", Protobuf.FromTransactionId(transactionId), (ResponseCode)receipt.Status);
             }
             var result = new TResult();
-            if (result is AccountRecord arec)
+            if (result is TransactionRecord arec)
             {
                 var record = await GetTransactionRecordAsync(context, transactionId);
                 Protobuf.FillRecordProperties(record, arec);
-                arec.Address = Protobuf.FromAccountID(receipt.AccountID);
             }
-            else if (result is AccountReceipt arcpt)
+            else if (result is TransactionReceipt arcpt)
             {
                 Protobuf.FillReceiptProperties(transactionId, receipt, arcpt);
-                arcpt.Address = Protobuf.FromAccountID(receipt.AccountID);
             }
             return result;
 

--- a/src/Hashgraph/Record/GetAccountRecords.cs
+++ b/src/Hashgraph/Record/GetAccountRecords.cs
@@ -47,7 +47,14 @@ namespace Hashgraph
                 var transactionId = Transactions.GetOrCreateTransactionID(context);
                 query.CryptoGetAccountRecords.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Account Records", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
-                ValidateResult.PreCheck(transactionId, getResponseCode(response));
+                // TESTNET 2020-01-23 Wait for Next Release to Put Back
+                //ValidateResult.PreCheck(transactionId, getResponseCode(response));
+                // TESTNET 2020-01-23 Temp Work Around
+                if(response.CryptoGetAccountRecords == null)
+                {
+                    throw new TransactionException("Unable to retrieve transaction records.", Protobuf.FromTransactionId(transactionId), (ResponseCode)getResponseCode(response));
+                }
+                // TESTNET 2020-01-23 End Temp Workaround
             }
             return response.CryptoGetAccountRecords.Records.Select(record =>
             {

--- a/src/Hashgraph/Record/GetTransactionRecord.cs
+++ b/src/Hashgraph/Record/GetTransactionRecord.cs
@@ -83,11 +83,18 @@ namespace Hashgraph
                 var transactionId = Transactions.GetOrCreateTransactionID(context);
                 query.TransactionGetRecord.Header = await Transactions.CreateAndSignQueryHeaderAsync(context, cost, "Get Transaction Record", transactionId);
                 response = await Transactions.ExecuteSignedRequestWithRetryAsync(context, query, getRequestMethod, getResponseCode);
-                var responseCode = getResponseCode(response);
-                if (responseCode != ResponseCodeEnum.Ok)
+                // TESTNET 2020-01-23 Wait for Next Release to Put Back
+                //var responseCode = getResponseCode(response);
+                //if (responseCode != ResponseCodeEnum.Ok)
+                //{
+                //    throw new TransactionException("Unable to retrieve transaction record.", Protobuf.FromTransactionId(transactionRecordId), (ResponseCode)responseCode);
+                //}
+                // TESTNET 2020-01-23 Temp Work Around
+                if (response.TransactionGetRecord.TransactionRecord == null)
                 {
-                    throw new TransactionException("Unable to retrieve transaction record.", Protobuf.FromTransactionId(transactionRecordId), (ResponseCode)responseCode);
+                    throw new TransactionException("Unable to retrieve transaction record.", Protobuf.FromTransactionId(transactionRecordId), (ResponseCode)getResponseCode(response));
                 }
+                // TESTNET 2020-01-23 End Temp Workaround
             }
             return response.TransactionGetRecord.TransactionRecord;
 

--- a/test/Hashgraph.Test/Contract/CallContractTests.cs
+++ b/test/Hashgraph.Test/Contract/CallContractTests.cs
@@ -31,7 +31,6 @@ namespace Hashgraph.Test.Contract
             Assert.NotNull(record.Concensus);
             Assert.Equal("Call Contract", record.Memo);
             Assert.InRange(record.Fee, 0UL, ulong.MaxValue);
-            Assert.Equal(fx.ContractRecord.Contract, record.Contract);
             Assert.Empty(record.CallResult.Error);
             Assert.True(record.CallResult.Bloom.IsEmpty);
             Assert.InRange(record.CallResult.Gas, 0UL, 30_000UL);
@@ -55,7 +54,6 @@ namespace Hashgraph.Test.Contract
             Assert.NotNull(record.Concensus);
             Assert.Equal("Call Contract", record.Memo);
             Assert.InRange(record.Fee, 0UL, ulong.MaxValue);
-            Assert.Equal(fx.ContractRecord.Contract, record.Contract);
             Assert.Empty(record.CallResult.Error);
             Assert.True(record.CallResult.Bloom.IsEmpty);
             Assert.InRange(record.CallResult.Gas, 0UL, 30_000UL);
@@ -76,7 +74,6 @@ namespace Hashgraph.Test.Contract
             }, ctx => ctx.Signatory = null);
             Assert.NotNull(receipt);
             Assert.Equal(ResponseCode.Success, receipt.Status);
-            Assert.Equal(fx.ContractRecord.Contract, receipt.Contract);
         }
         [Fact(DisplayName = "Call Contract: Can Call Contract that sets State")]
         public async Task CanCreateAContractAndSetStateAsync()
@@ -97,7 +94,6 @@ namespace Hashgraph.Test.Contract
             Assert.NotNull(setRecord.Concensus);
             Assert.Equal("Call Contract", setRecord.Memo);
             Assert.InRange(setRecord.Fee, 0UL, ulong.MaxValue);
-            Assert.Equal(fx.ContractRecord.Contract, setRecord.Contract);
             Assert.Empty(setRecord.CallResult.Error);
             Assert.True(setRecord.CallResult.Bloom.IsEmpty);
             Assert.InRange(setRecord.CallResult.Gas, 0UL, 50_000UL);
@@ -115,7 +111,6 @@ namespace Hashgraph.Test.Contract
             Assert.NotNull(getRecord.Concensus);
             Assert.Equal("Call Contract", getRecord.Memo);
             Assert.InRange(getRecord.Fee, 0UL, ulong.MaxValue);
-            Assert.Equal(fx.ContractRecord.Contract, getRecord.Contract);
             Assert.Empty(getRecord.CallResult.Error);
             Assert.True(getRecord.CallResult.Bloom.IsEmpty);
             Assert.InRange(getRecord.CallResult.Gas, 0UL, 30_000UL);
@@ -138,7 +133,6 @@ namespace Hashgraph.Test.Contract
             });
             Assert.NotNull(setRecord);
             Assert.Equal(ResponseCode.Success, setRecord.Status);
-            Assert.Equal(fx.ContractRecord.Contract, setRecord.Contract);
 
             var getRecord = await fx.Client.CallContractWithRecordAsync(new CallContractParams
             {
@@ -152,7 +146,6 @@ namespace Hashgraph.Test.Contract
             Assert.NotNull(getRecord.Concensus);
             Assert.Equal("Call Contract", getRecord.Memo);
             Assert.InRange(getRecord.Fee, 0UL, ulong.MaxValue);
-            Assert.Equal(fx.ContractRecord.Contract, getRecord.Contract);
             Assert.Empty(getRecord.CallResult.Error);
             Assert.True(getRecord.CallResult.Bloom.IsEmpty);
             Assert.InRange(getRecord.CallResult.Gas, 0UL, 30_000UL);

--- a/test/Hashgraph.Test/Contract/QueryContractTests.cs
+++ b/test/Hashgraph.Test/Contract/QueryContractTests.cs
@@ -64,7 +64,8 @@ namespace Hashgraph.Test.Contract
                     Contract = fx.ContractRecord.Contract,
                     Gas = await _network.TinybarsFromGas(400),
                     FunctionName = "set_message",
-                    FunctionArgs = new object[] { newMessage }
+                    FunctionArgs = new object[] { newMessage },
+                    ReturnValueCharge = 700
                 });
             });
             Assert.Equal(ResponseCode.LocalCallModificationException, pex.Status);
@@ -82,6 +83,7 @@ namespace Hashgraph.Test.Contract
                     Contract = fx.ContractRecord.Contract,
                     Gas = await _network.TinybarsFromGas(400),
                     FunctionName = "greet",
+                    ReturnValueCharge = 1000,
                     MaxAllowedReturnSize = 1
                 });
             });

--- a/test/Hashgraph.Test/Fixtures/EventEmittingContract.cs
+++ b/test/Hashgraph.Test/Fixtures/EventEmittingContract.cs
@@ -11,7 +11,7 @@ namespace Hashgraph.Test.Fixtures
         public CreateFileParams FileParams;
         public FileRecord FileRecord;
         public CreateContractParams ContractParams;
-        public ContractRecord ContractRecord;
+        public CreateContractRecord ContractRecord;
         public NetworkCredentials Network;
 
         /// <summary>

--- a/test/Hashgraph.Test/Fixtures/GreetingContract.cs
+++ b/test/Hashgraph.Test/Fixtures/GreetingContract.cs
@@ -13,7 +13,7 @@ namespace Hashgraph.Test.Fixtures
         public CreateFileParams FileParams;
         public FileRecord FileRecord;
         public CreateContractParams ContractParams;
-        public ContractRecord ContractRecord;
+        public CreateContractRecord ContractRecord;
         public NetworkCredentials Network;
 
         /// <summary>

--- a/test/Hashgraph.Test/Fixtures/PayableContract.cs
+++ b/test/Hashgraph.Test/Fixtures/PayableContract.cs
@@ -11,7 +11,7 @@ namespace Hashgraph.Test.Fixtures
         public CreateFileParams FileParams;
         public FileRecord FileRecord;
         public CreateContractParams ContractParams;
-        public ContractRecord ContractRecord;
+        public CreateContractRecord ContractRecord;
         public NetworkCredentials Network;
 
         /// <summary>

--- a/test/Hashgraph.Test/Fixtures/StatefulContract.cs
+++ b/test/Hashgraph.Test/Fixtures/StatefulContract.cs
@@ -11,7 +11,7 @@ namespace Hashgraph.Test.Fixtures
         public CreateFileParams FileParams;
         public FileRecord FileRecord;
         public CreateContractParams ContractParams;
-        public ContractRecord ContractRecord;
+        public CreateContractRecord ContractRecord;
         public NetworkCredentials Network;
 
         /// <summary>

--- a/test/Hashgraph.Test/Fixtures/TestAccount.cs
+++ b/test/Hashgraph.Test/Fixtures/TestAccount.cs
@@ -9,7 +9,7 @@ namespace Hashgraph.Test.Fixtures
         public ReadOnlyMemory<byte> PublicKey;
         public ReadOnlyMemory<byte> PrivateKey;
         public CreateAccountParams CreateParams;
-        public AccountRecord Record;
+        public CreateAccountRecord Record;
         public NetworkCredentials Network;
         public Client Client;
 


### PR DESCRIPTION
Modifications to bring the SDK into
compatibility with the testnet updates
of January 23, 2020.  These are breaking
changes, which include:

Changed signature of CallContractAsync
to return a TransactionReceipt. The network
no longer returns the contract ID with the
results of the method call.

Removed ContractID from
CallContractRecord which is returned from
CallContractWithRecordAsync. The network no
longer returns the contract ID with the results
of the method call.

Renamed ContractReceipt to
CreateContractReceipt which is returned from
CreateContractAsync.

Renamed ContractRecord to
CreateContractRecord which is returned from
CreateContractWithRecordAsync.

Renamed AccountReceipt to
CreateAccountReceipt which is returned from
CreateAccountAsync.

Renamed AccountRecord to
CreateAccountRecord which is returned from
CreateAccountWithRecordAsync.

Changed signature of UpdateAccountAsync to
return a TransactionReceipt. The network no
longer returns the Account ID with the results
of the method call.

Changed signature of
UpdateAccountWithRecordAsync to return a
TransactionRecord. The network no longer
returns the Account ID with the results of the
method call.

Temporary relaxing of error checking when
retrieving records, which will be restored in
conjunction with the next testnet release cycle.