### PR TITLE
Add actions for platform builds, tests and dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Create pull requests on updates to nuget packages, hedera-protobufs or github actions
+version: 2
+updates:
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,77 @@
+#  Required variables set by GitHub environment secrets
+#  Platform specific test accounts reduce insufficient account balance problems
+#
+#  TEST_ACCOUNT_NUMBER_MACOS:         Address number for MaxOS tests of the account making requests (assumes Realm = 0, Shard = 0)
+#  TEST_ACCOUNT_NUMBER_UBUNTU:        Address number for Ubuntu tests
+#  TEST_ACCOUNT_NUMBER_WINDOWS:       Address number for Windows tests
+#  TEST_ACCOUNT_PRIVATE_KEY_MACOS:    Private Key for MaxOS tests of account making requests of the network, encoded in Hex
+#  TEST_ACCOUNT_PRIVATE_KEY_UBUNTU:   Private Key for Ubuntu tests
+#  TEST_ACCOUNT_PRIVATE_KEY_WINDOWS:  Private Key for Windows tests
+#  TEST_ACCOUNT_PUBLIC_KEY_MACOS:     Public Key for MaxOS tests of account making requests of the network, encoded in Hex (last 32 bytes)
+#  TEST_ACCOUNT_PUBLIC_KEY_UBUNTU:    Public Key for Ubuntu tests
+#  TEST_ACCOUNT_PUBLIC_KEY_WINDOWS:   Public Key for Windows tests
+#  TEST_MIRROR_ADDRESS:               Mirror Node DNS name, for example 'testnet.mirrornode.hedera.com'
+#  TEST_MIRROR_PORT:                  Mirror Node port number
+#  TEST_NETWORK_ADDRESS:              Test Network DNS name, for example 'testnet.hedera.com'
+#  TEST_NETWORK_PORT:                 Test Network port number
+#  TEST_SERVER_NUMBER:                Network Node Address Number receiving Network Requests (assumes Realm = 0, Shard = 0)
+
+name: Build
+
+on:
+  push:
+    branches: [ master, previewnet ]
+  pull_request:
+    branches: [ master, previewnet ]
+
+jobs:
+  build:
+    environment: Test
+    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    timeout-minutes: 360
+    env:
+      buildConfiguration: Release
+      minimumBalance: 2500 # ~2,200ℏ needed per test run
+      DOTNET_NOLOGO: true
+      TEST_ACCOUNT_NUMBER: ${{ secrets[format('TEST_ACCOUNT_NUMBER_{0}', matrix.os)] }}
+      TEST_ACCOUNT_PUBLIC_KEY: ${{ secrets[format('TEST_ACCOUNT_PUBLIC_KEY_{0}', matrix.os)] }}
+      TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets[format('TEST_ACCOUNT_PRIVATE_KEY_{0}', matrix.os)] }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows, macOS]
+
+    steps:
+    - name: Checkout 🛎️
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: true # TODO: .nuget package for hedera-protobufs?
+
+    - name: Setup .NET 👷
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+
+    - name: Build 🚀
+      run: dotnet build --configuration ${{ env.buildConfiguration }}
+
+    - name: Check Ħ account balance 💰
+      uses: si618/hedera-check-balance@latest
+      with:
+        operator-id: '0.0.${{ env.TEST_ACCOUNT_NUMBER }}'
+        operator-key: ${{ env.TEST_ACCOUNT_PRIVATE_KEY }}
+        minimum-balance: ${{ env.minimumBalance }}
+
+    - name: Test ✅
+      run: dotnet test --configuration ${{ env.buildConfiguration }} --no-build --verbosity normal
+      env:
+        'account:number': ${{ env.TEST_ACCOUNT_NUMBER }}
+        'account:publicKey': ${{ env.TEST_ACCOUNT_PUBLIC_KEY }}
+        'account:privateKey': ${{ env.TEST_ACCOUNT_PRIVATE_KEY }}
+        'mirror:address': ${{ secrets.TEST_MIRROR_ADDRESS }}
+        'mirror:port': ${{ secrets.TEST_MIRROR_PORT }}
+        'network:address': ${{ secrets.TEST_NETWORK_ADDRESS }}
+        'network:port': ${{ secrets.TEST_NETWORK_PORT }}
+        'server:number': ${{ secrets.TEST_SERVER_NUMBER }}


### PR DESCRIPTION
Add support for building and testing on latest windows, ubuntu and macOS platforms.

Each platform test uses separate Hedera accounts, with account balances checked by https://github.com/si618/hedera-check-balance. Tests will not run if there are insufficient hbars.

Add dependabot action to create pull requests when updates are available to nuget packages, hedera-protobufs submodule or github actions.